### PR TITLE
Fixes #51 - Added check for teams in user profile

### DIFF
--- a/src/helpers/authHelper.ts
+++ b/src/helpers/authHelper.ts
@@ -3,7 +3,9 @@ import { TeamRole } from '@/enums'
 import { DISCORD_ADMIN_IDS } from '@/consts'
 
 export function canEditTeamWithId(profile:UserProfile, id:string):boolean {
-  return id in profile.teams && profile.teams[id] === TeamRole.admin
+  return 'teams' in profile &&
+         id in profile.teams && 
+         profile.teams[id] === TeamRole.admin
 }
 
 export function canEditCompetitions(oauth:OAuth):boolean {


### PR DESCRIPTION
## Description of the change

Fixed a null pointer issue.  An authenticated User who had no teams was not able to view the details of other teams. Turned out to be a null pointer issue to 'profile.teams' in the authHelper canEditTeamWithId function.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Code review 

- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
