### PR TITLE
Bug/60 enter comp

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -51,11 +51,12 @@ export default defineComponent({
   },
   methods: {
     logout() {
-      this.userStore.logout().then(result => {
-        this.$router.push({'name': 'root'})
-          .then(() => {
-            this.flashStore.$patch({ message: 'You have been logged out.', level: LogLevel.success })
-          })
+      this.userStore.logout()
+        .then(() => {
+          this.$router.push({'name': 'root'})
+            .then(() => {
+              this.flashStore.$patch({ message: 'You have been logged out.', level: LogLevel.success })
+            })
       })
     }
   }

--- a/src/components/competition/CompetitionList.vue
+++ b/src/components/competition/CompetitionList.vue
@@ -125,14 +125,10 @@ export default defineComponent({
   methods: {
     getCompState,
     onEnterCompetition(comp:Competition) {
-      this.modalStore.options = {
-        component: 'EnterCompetition',
-        title: '',
-        fullscreen: true,
-        meta: {
-          competition: comp
-        }
-      }
+      this.$router.push({
+        name: 'comp-enter',
+        params: { id: comp.id }
+      })
     }
   }
 })

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -16,3 +16,5 @@ export const PAGING_SIZE:number = 10
 export const ERROR_PAGE_LOAD:string = "We've hit an error. Please try a page refresh."
 export const ERROR_NOT_FOUND:string = "Sorry, but we couldn't find the resource you were looking for."
 export const ERROR_AUTH:string = "Sorry, but you don't have permission to access that page." 
+
+export const KEY_REDIRECT_PATH:string = "redirect_path"

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -6,6 +6,7 @@ import CompetitionShow from '@/views/competitions/CompetitionShow.vue'
 import CompetitionDetail from '@/views/competitions/CompetitionDetail.vue'
 import CompetitionNew from '@/views/competitions/CompetitionNew.vue'
 import CompetitionEdit from '@/views/competitions/CompetitionEdit.vue'
+import CompetitionEnter from '@/views/competitions/CompetitionEnter.vue'
 import CompetitionProject from '@/views/competition_projects/CompetitionProject.vue'
 import CompetitionProjects from '@/views/competition_projects/CompetitionProjects.vue'
 import CompetitionResults from '@/views/competition_results/CompetitionResults.vue'
@@ -106,6 +107,11 @@ const routes: RouteRecordRaw[] = [
             component: CompetitionDetail
           },
           {
+            path: 'enter',
+            name: 'comp-enter',
+            component: CompetitionEnter
+          },
+          {
             path: 'projects',
             name: 'comp-projects',
             component: CompetitionProjects
@@ -157,16 +163,15 @@ const router = createRouter({
 })
 
 router.beforeEach(async (to, from) => {
-  const store = useUserStore()
+  const userStore = useUserStore()
   const flash = useFlashStore()
   const modal = useModalStore()
   flash.$reset()
   modal.$reset()
 
-  if (store.oauth && !store.profile && to.name !== 'auth_callback') {
+  if (userStore.oauth && !userStore.profile && to.name !== 'auth_callback') {
     return { name: 'auth_callback', query: { redirect: to.path }}
   }
-
 })
 
 export default router

--- a/src/views/AuthCallback.vue
+++ b/src/views/AuthCallback.vue
@@ -13,6 +13,7 @@ import { useFlashStore } from '@/store/flash'
 import Loading from '@/components/Loading.vue'
 import log from '@/services/logger'
 import { LogLevel } from '@/enums'
+import { KEY_REDIRECT_PATH } from '@/consts'
 
 const MODULE_ID = 'views/AuthCallback'
 const LOGIN_ERROR = 'An unknown error occurred. Please try again.'
@@ -53,16 +54,20 @@ export default defineComponent({
           await this.userStore.fetchUser(user.uid, user.photoURL || '')
           await this.userStore.fetchUserGuild()
           if (!this.userStore.profile || !this.userStore.guild) {
-            unsubscribe()
             this.logout({
               message: !this.userStore.profile ? LOGIN_ERROR : GUILD_ERROR,
               level: LogLevel.error
             })
           }
           else {
-            let redirect = this.$route.query.redirect as string || '/'
+            const storedRedirect = sessionStorage.getItem(KEY_REDIRECT_PATH)
+            if (storedRedirect) {
+              sessionStorage.removeItem(KEY_REDIRECT_PATH)
+            }
+            const redirect = this.$route.query.redirect as string || storedRedirect || '/'
             this.$router.replace({ path: redirect })
           }
+          unsubscribe()
         }
         catch(error) {
           let message = (error instanceof Error) ? error.message : String(error)

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -16,14 +16,18 @@ import { defineComponent } from 'vue'
 import auth from '@/services/auth'
 import { useUserStore } from '@/store/user'
 import Flash from '@/components/Flash.vue'
+import { KEY_REDIRECT_PATH } from '@/consts'
 
 export default defineComponent({
   components: { Flash },
   beforeRouteEnter(to, from) {
+    const redirect = to.query.redirect as string
     let store = useUserStore()
     if (store.oauth) {
-      let redirect = to.query.redirect as string
       return redirect || '/'
+    }
+    else {
+      sessionStorage.setItem(KEY_REDIRECT_PATH, redirect || from.path)
     }
   },
   methods: {

--- a/src/views/competitions/CompetitionEnter.vue
+++ b/src/views/competitions/CompetitionEnter.vue
@@ -1,0 +1,53 @@
+<template>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import { Competition } from '@/types'
+import { useUserStore } from '@/store/user'
+import { useModalStore } from '@/store/modal'
+import { mapStores } from 'pinia'
+
+export default defineComponent({
+  props: {
+    competition: {
+      type: Object as () => Competition,
+      required: true
+    }
+  },
+  computed: {
+    ...mapStores(useUserStore, useModalStore)
+  },
+  beforeRouteEnter (to, from, next) {
+    next(vm => {
+      const that = (vm as any)
+      that.openWizard()
+    })
+  },
+  methods: {
+    openWizard() {
+      if (this.userStore.isAuthenticated) {
+        this.$router.replace({ 
+          name: 'comp-show', 
+          params: { id: this.competition.id }
+        })
+        .then(() => {
+          this.modalStore.options = {
+            component: 'EnterCompetition',
+            title: '',
+            fullscreen: true,
+            meta: {
+              competition: this.competition
+            }
+          }
+        })
+      }
+      else {
+        this.$router.push({ 
+          name: 'login'
+        })
+      }
+    }
+  }
+})
+</script>

--- a/src/views/competitions/CompetitionShow.vue
+++ b/src/views/competitions/CompetitionShow.vue
@@ -262,13 +262,11 @@ export default defineComponent({
         })
     },
     onEnterCompetition() {
-      this.modalStore.options = {
-        component: 'EnterCompetition',
-        title: '',
-        fullscreen: true,
-        meta: {
-          competition: this.competition
-        }
+      if (this.competition) {
+        this.$router.push({
+          name: 'comp-enter',
+          params: { id: this.competition.id }
+        })
       }
     },
     saveCompetition(comp:Competition):Promise<Competition|undefined> {


### PR DESCRIPTION
## Description of the change

Addresses issue #60. Users need to be Authenticated before they can enter a competition. Some notes:

1. The Login view will store the "from" route, if it exists, so we can redirect to it after a successful login.
1. I created a route and view for entering a competition. This view is more or less just a placeholder for opening a `/src/modals/EnterCompetition.vue` component. 

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Code review 

- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
