### PR TITLE
Version bumps for vite, vue-tsc, and firebase-tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,11 +19,11 @@
       "devDependencies": {
         "@types/quill": "^2.0.9",
         "@vitejs/plugin-vue": "^3.0.3",
-        "firebase-tools": "^11.13.0",
+        "firebase-tools": "^11.16.1",
         "sass": "^1.54.8",
         "typescript": "^4.6.4",
-        "vite": "^3.0.7",
-        "vue-tsc": "^0.39.5"
+        "vite": "^3.2.4",
+        "vue-tsc": "^1.0.10"
       }
     },
     "node_modules/@babel/parser": {
@@ -736,65 +736,173 @@
         "vue": "^3.2.25"
       }
     },
-    "node_modules/@volar/code-gen": {
-      "version": "0.39.5",
-      "resolved": "https://registry.npmjs.org/@volar/code-gen/-/code-gen-0.39.5.tgz",
-      "integrity": "sha512-vQr5VoCH8T2NHmqLc/AA1/4F8l41WB+24+I+VjxBaev/Hmwjye9K0GlmMHAOl84WB3hWGOqpHaPX6JkqzRNjJg==",
+    "node_modules/@volar/language-core": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.0.10.tgz",
+      "integrity": "sha512-7WNzjvdUXjggEZvYu9EInABl4mvXtyiiaJDOJM+plHJT7xW5voLja0BrYYji6TUn8Q4HakLvTPpQddPLq134mg==",
       "dev": true,
       "dependencies": {
-        "@volar/source-map": "0.39.5"
+        "@volar/source-map": "1.0.10",
+        "@vue/reactivity": "^3.2.45",
+        "muggle-string": "^0.1.0"
       }
     },
-    "node_modules/@volar/source-map": {
-      "version": "0.39.5",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-0.39.5.tgz",
-      "integrity": "sha512-IVOX+v++Sr5Kok4/cLbDJp2vf1ia1rChpV7adgcnMle6uORBuGFEur234UzamK0iHRCcfFFRz7z+hSPf2CO23Q==",
+    "node_modules/@volar/language-core/node_modules/@vue/reactivity": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.45.tgz",
+      "integrity": "sha512-PRvhCcQcyEVohW0P8iQ7HDcIOXRjZfAsOds3N99X/Dzewy8TVhTCT4uXpAHfoKjVTJRA0O0K+6QNkDIZAxNi3A==",
+      "dev": true,
+      "dependencies": {
+        "@vue/shared": "3.2.45"
+      }
+    },
+    "node_modules/@volar/language-core/node_modules/@vue/shared": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.45.tgz",
+      "integrity": "sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg==",
       "dev": true
     },
-    "node_modules/@volar/typescript-faster": {
-      "version": "0.39.5",
-      "resolved": "https://registry.npmjs.org/@volar/typescript-faster/-/typescript-faster-0.39.5.tgz",
-      "integrity": "sha512-IzLqlxefmKkjNKXC/8aFiqPcTqnj6RG31D2f9cIWxmW9pvUYJxLED+y9phnOxNxq0OmeRtQ3Pfmvu85tUBoZsQ==",
+    "node_modules/@volar/source-map": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.0.10.tgz",
+      "integrity": "sha512-jSZW1tfsvAOHlpoRy14zH9sdCYR4g8QcnCXRli8juFC2UHoVzVRKB6VdnXcx5wRAlIRXoiBpsU+pKminryKEBw==",
       "dev": true,
       "dependencies": {
-        "semver": "^7.3.7"
+        "muggle-string": "^0.1.0"
       }
     },
-    "node_modules/@volar/vue-code-gen": {
-      "version": "0.39.5",
-      "resolved": "https://registry.npmjs.org/@volar/vue-code-gen/-/vue-code-gen-0.39.5.tgz",
-      "integrity": "sha512-y+QUV9MuuasiIuRoGKQl+gMhDaAX6XNhckAyJCvD1FZ8f2eJuPY2VtoFxmu/Z2bGWBdtUW/g98jaeKJ+j3wwOw==",
+    "node_modules/@volar/typescript": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.0.10.tgz",
+      "integrity": "sha512-Nd+u2Z2P1V+KiNBMLLK6wV4sswOOYBsjEHmgK29eENXtos1+gF2GWB908vvwmT75dmCtlYZ8No14lvCqXUAVdg==",
       "dev": true,
       "dependencies": {
-        "@volar/code-gen": "0.39.5",
-        "@volar/source-map": "0.39.5",
-        "@vue/compiler-core": "^3.2.37",
-        "@vue/compiler-dom": "^3.2.37",
-        "@vue/shared": "^3.2.37"
+        "@volar/language-core": "1.0.10"
       }
     },
     "node_modules/@volar/vue-language-core": {
-      "version": "0.39.5",
-      "resolved": "https://registry.npmjs.org/@volar/vue-language-core/-/vue-language-core-0.39.5.tgz",
-      "integrity": "sha512-m+e1tYuL/WRPhSeC7hZ0NuSwHsfnnGJVxCBHLaP7jR0f6xcC0DAegP3QF+gfu9ZJFPGznpZYFKadngMjuhQS9Q==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@volar/vue-language-core/-/vue-language-core-1.0.10.tgz",
+      "integrity": "sha512-m7pYXGwkpF9Bmuud73kGlAX31QUTwifYbgCenaqm3hGNh+SJebSkxzk4NJvabiGbA6ON3b5ayQZ/rbOEtdoghw==",
       "dev": true,
       "dependencies": {
-        "@volar/code-gen": "0.39.5",
-        "@volar/source-map": "0.39.5",
-        "@volar/vue-code-gen": "0.39.5",
-        "@vue/compiler-sfc": "^3.2.37",
-        "@vue/reactivity": "^3.2.37"
+        "@volar/language-core": "1.0.10",
+        "@volar/source-map": "1.0.10",
+        "@vue/compiler-dom": "^3.2.45",
+        "@vue/compiler-sfc": "^3.2.45",
+        "@vue/reactivity": "^3.2.45",
+        "@vue/shared": "^3.2.45",
+        "minimatch": "^5.1.0",
+        "vue-template-compiler": "^2.7.14"
+      }
+    },
+    "node_modules/@volar/vue-language-core/node_modules/@vue/compiler-core": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.45.tgz",
+      "integrity": "sha512-rcMj7H+PYe5wBV3iYeUgbCglC+pbpN8hBLTJvRiK2eKQiWqu+fG9F+8sW99JdL4LQi7Re178UOxn09puSXvn4A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.16.4",
+        "@vue/shared": "3.2.45",
+        "estree-walker": "^2.0.2",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/@volar/vue-language-core/node_modules/@vue/compiler-dom": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.45.tgz",
+      "integrity": "sha512-tyYeUEuKqqZO137WrZkpwfPCdiiIeXYCcJ8L4gWz9vqaxzIQRccTSwSWZ/Axx5YR2z+LvpUbmPNXxuBU45lyRw==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-core": "3.2.45",
+        "@vue/shared": "3.2.45"
+      }
+    },
+    "node_modules/@volar/vue-language-core/node_modules/@vue/compiler-sfc": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.45.tgz",
+      "integrity": "sha512-1jXDuWah1ggsnSAOGsec8cFjT/K6TMZ0sPL3o3d84Ft2AYZi2jWJgRMjw4iaK0rBfA89L5gw427H4n1RZQBu6Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.16.4",
+        "@vue/compiler-core": "3.2.45",
+        "@vue/compiler-dom": "3.2.45",
+        "@vue/compiler-ssr": "3.2.45",
+        "@vue/reactivity-transform": "3.2.45",
+        "@vue/shared": "3.2.45",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.25.7",
+        "postcss": "^8.1.10",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/@volar/vue-language-core/node_modules/@vue/compiler-ssr": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.45.tgz",
+      "integrity": "sha512-6BRaggEGqhWht3lt24CrIbQSRD5O07MTmd+LjAn5fJj568+R9eUD2F7wMQJjX859seSlrYog7sUtrZSd7feqrQ==",
+      "dev": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.2.45",
+        "@vue/shared": "3.2.45"
+      }
+    },
+    "node_modules/@volar/vue-language-core/node_modules/@vue/reactivity": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.45.tgz",
+      "integrity": "sha512-PRvhCcQcyEVohW0P8iQ7HDcIOXRjZfAsOds3N99X/Dzewy8TVhTCT4uXpAHfoKjVTJRA0O0K+6QNkDIZAxNi3A==",
+      "dev": true,
+      "dependencies": {
+        "@vue/shared": "3.2.45"
+      }
+    },
+    "node_modules/@volar/vue-language-core/node_modules/@vue/reactivity-transform": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.45.tgz",
+      "integrity": "sha512-BHVmzYAvM7vcU5WmuYqXpwaBHjsS8T63jlKGWVtHxAHIoMIlmaMyurUSEs1Zcg46M4AYT5MtB1U274/2aNzjJQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.16.4",
+        "@vue/compiler-core": "3.2.45",
+        "@vue/shared": "3.2.45",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.25.7"
+      }
+    },
+    "node_modules/@volar/vue-language-core/node_modules/@vue/shared": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.45.tgz",
+      "integrity": "sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg==",
+      "dev": true
+    },
+    "node_modules/@volar/vue-language-core/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@volar/vue-language-core/node_modules/minimatch": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
+      "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@volar/vue-typescript": {
-      "version": "0.39.5",
-      "resolved": "https://registry.npmjs.org/@volar/vue-typescript/-/vue-typescript-0.39.5.tgz",
-      "integrity": "sha512-ckhWD1xOi0OMr702XVkv/Npsb9FKAp5gvhxyLv0QqWekPdSo04t4KrZfwosJLGERIEcyr50SuB7HqBp8ndQmzA==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@volar/vue-typescript/-/vue-typescript-1.0.10.tgz",
+      "integrity": "sha512-GjQ+mfIUljXGfkTmNrfNT8YYQY48mcOE5SJ190o6ENArzH9cqjmvPLo1nrdurbZOFwztwEDNye5N1/5aL9sZ1g==",
       "dev": true,
       "dependencies": {
-        "@volar/code-gen": "0.39.5",
-        "@volar/typescript-faster": "0.39.5",
-        "@volar/vue-language-core": "0.39.5"
+        "@volar/typescript": "1.0.10",
+        "@volar/vue-language-core": "1.0.10"
       }
     },
     "node_modules/@vue/compiler-core": {
@@ -1067,6 +1175,12 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
       "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
     },
+    "node_modules/de-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
+      "dev": true
+    },
     "node_modules/deep-equal": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
@@ -1104,9 +1218,9 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/esbuild": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.8.tgz",
-      "integrity": "sha512-Remsk2dmr1Ia65sU+QasE6svJbsHe62lzR+CnjpUvbZ+uSYo1SitiOWPRfZQkCu82YWZBBKXiD/j0i//XWMZ+Q==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.16.tgz",
+      "integrity": "sha512-o6iS9zxdHrrojjlj6pNGC2NAg86ECZqIETswTM5KmJitq+R1YmahhWtMumeQp9lHqJaROGnsBi2RLawGnfo5ZQ==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -1116,28 +1230,28 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.15.8",
-        "@esbuild/linux-loong64": "0.15.8",
-        "esbuild-android-64": "0.15.8",
-        "esbuild-android-arm64": "0.15.8",
-        "esbuild-darwin-64": "0.15.8",
-        "esbuild-darwin-arm64": "0.15.8",
-        "esbuild-freebsd-64": "0.15.8",
-        "esbuild-freebsd-arm64": "0.15.8",
-        "esbuild-linux-32": "0.15.8",
-        "esbuild-linux-64": "0.15.8",
-        "esbuild-linux-arm": "0.15.8",
-        "esbuild-linux-arm64": "0.15.8",
-        "esbuild-linux-mips64le": "0.15.8",
-        "esbuild-linux-ppc64le": "0.15.8",
-        "esbuild-linux-riscv64": "0.15.8",
-        "esbuild-linux-s390x": "0.15.8",
-        "esbuild-netbsd-64": "0.15.8",
-        "esbuild-openbsd-64": "0.15.8",
-        "esbuild-sunos-64": "0.15.8",
-        "esbuild-windows-32": "0.15.8",
-        "esbuild-windows-64": "0.15.8",
-        "esbuild-windows-arm64": "0.15.8"
+        "@esbuild/android-arm": "0.15.16",
+        "@esbuild/linux-loong64": "0.15.16",
+        "esbuild-android-64": "0.15.16",
+        "esbuild-android-arm64": "0.15.16",
+        "esbuild-darwin-64": "0.15.16",
+        "esbuild-darwin-arm64": "0.15.16",
+        "esbuild-freebsd-64": "0.15.16",
+        "esbuild-freebsd-arm64": "0.15.16",
+        "esbuild-linux-32": "0.15.16",
+        "esbuild-linux-64": "0.15.16",
+        "esbuild-linux-arm": "0.15.16",
+        "esbuild-linux-arm64": "0.15.16",
+        "esbuild-linux-mips64le": "0.15.16",
+        "esbuild-linux-ppc64le": "0.15.16",
+        "esbuild-linux-riscv64": "0.15.16",
+        "esbuild-linux-s390x": "0.15.16",
+        "esbuild-netbsd-64": "0.15.16",
+        "esbuild-openbsd-64": "0.15.16",
+        "esbuild-sunos-64": "0.15.16",
+        "esbuild-windows-32": "0.15.16",
+        "esbuild-windows-64": "0.15.16",
+        "esbuild-windows-arm64": "0.15.16"
       }
     },
     "node_modules/esbuild-android-64": {
@@ -1176,9 +1290,9 @@
       }
     },
     "node_modules/esbuild-darwin-64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.8.tgz",
-      "integrity": "sha512-KaKcGfJ+yto7Fo5gAj3xwxHMd1fBIKatpCHK8znTJLVv+9+NN2/tIPBqA4w5rBwjX0UqXDeIE2v1xJP+nGEXgA==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.16.tgz",
+      "integrity": "sha512-wo2VWk/n/9V2TmqUZ/KpzRjCEcr00n7yahEdmtzlrfQ3lfMCf3Wa+0sqHAbjk3C6CKkR3WKK/whkMq5Gj4Da9g==",
       "cpu": [
         "x64"
       ],
@@ -1476,6 +1590,342 @@
         "node": ">=12"
       }
     },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm": {
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.16.tgz",
+      "integrity": "sha512-nyB6CH++2mSgx3GbnrJsZSxzne5K0HMyNIWafDHqYy7IwxFc4fd/CgHVZXr8Eh+Q3KbIAcAe3vGyqIPhGblvMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.16.tgz",
+      "integrity": "sha512-SDLfP1uoB0HZ14CdVYgagllgrG7Mdxhkt4jDJOKl/MldKrkQ6vDJMZKl2+5XsEY/Lzz37fjgLQoJBGuAw/x8kQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-android-64": {
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.16.tgz",
+      "integrity": "sha512-Vwkv/sT0zMSgPSVO3Jlt1pUbnZuOgtOQJkJkyyJFAlLe7BiT8e9ESzo0zQSx4c3wW4T6kGChmKDPMbWTgtliQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-android-arm64": {
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.16.tgz",
+      "integrity": "sha512-lqfKuofMExL5niNV3gnhMUYacSXfsvzTa/58sDlBET/hCOG99Zmeh+lz6kvdgvGOsImeo6J9SW21rFCogNPLxg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-darwin-arm64": {
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.16.tgz",
+      "integrity": "sha512-fMXaUr5ou0M4WnewBKsspMtX++C1yIa3nJ5R2LSbLCfJT3uFdcRoU/NZjoM4kOMKyOD9Sa/2vlgN8G07K3SJnw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-freebsd-64": {
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.16.tgz",
+      "integrity": "sha512-UzIc0xlRx5x9kRuMr+E3+hlSOxa/aRqfuMfiYBXu2jJ8Mzej4lGL7+o6F5hzhLqWfWm1GWHNakIdlqg1ayaTNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-freebsd-arm64": {
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.16.tgz",
+      "integrity": "sha512-8xyiYuGc0DLZphFQIiYaLHlfoP+hAN9RHbE+Ibh8EUcDNHAqbQgUrQg7pE7Bo00rXmQ5Ap6KFgcR0b4ALZls1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-linux-32": {
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.16.tgz",
+      "integrity": "sha512-iGijUTV+0kIMyUVoynK0v+32Oi8yyp0xwMzX69GX+5+AniNy/C/AL1MjFTsozRp/3xQPl7jVux/PLe2ds10/2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-linux-64": {
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.16.tgz",
+      "integrity": "sha512-tuSOjXdLw7VzaUj89fIdAaQT7zFGbKBcz4YxbWrOiXkwscYgE7HtTxUavreBbnRkGxKwr9iT/gmeJWNm4djy/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-linux-arm": {
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.16.tgz",
+      "integrity": "sha512-XKcrxCEXDTOuoRj5l12tJnkvuxXBMKwEC5j0JISw3ziLf0j4zIwXbKbTmUrKFWbo6ZgvNpa7Y5dnbsjVvH39bQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-linux-arm64": {
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.16.tgz",
+      "integrity": "sha512-mPYksnfHnemNrvjrDhZyixL/AfbJN0Xn9S34ZOHYdh6/jJcNd8iTsv3JwJoEvTJqjMggjMhGUPJAdjnFBHoH8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-linux-mips64le": {
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.16.tgz",
+      "integrity": "sha512-kSJO2PXaxfm0pWY39+YX+QtpFqyyrcp0ZeI8QPTrcFVQoWEPiPVtOfTZeS3ZKedfH+Ga38c4DSzmKMQJocQv6A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-linux-ppc64le": {
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.16.tgz",
+      "integrity": "sha512-NimPikwkBY0yGABw6SlhKrtT35sU4O23xkhlrTT/O6lSxv3Pm5iSc6OYaqVAHWkLdVf31bF4UDVFO+D990WpAA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-linux-riscv64": {
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.16.tgz",
+      "integrity": "sha512-ty2YUHZlwFOwp7pR+J87M4CVrXJIf5ZZtU/umpxgVJBXvWjhziSLEQxvl30SYfUPq0nzeWKBGw5i/DieiHeKfw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-linux-s390x": {
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.16.tgz",
+      "integrity": "sha512-VkZaGssvPDQtx4fvVdZ9czezmyWyzpQhEbSNsHZZN0BHvxRLOYAQ7sjay8nMQwYswP6O2KlZluRMNPYefFRs+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-netbsd-64": {
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.16.tgz",
+      "integrity": "sha512-ElQ9rhdY51et6MJTWrCPbqOd/YuPowD7Cxx3ee8wlmXQQVW7UvQI6nSprJ9uVFQISqSF5e5EWpwWqXZsECLvXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-openbsd-64": {
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.16.tgz",
+      "integrity": "sha512-KgxMHyxMCT+NdLQE1zVJEsLSt2QQBAvJfmUGDmgEq8Fvjrf6vSKB00dVHUEDKcJwMID6CdgCpvYNt999tIYhqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-sunos-64": {
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.16.tgz",
+      "integrity": "sha512-exSAx8Phj7QylXHlMfIyEfNrmqnLxFqLxdQF6MBHPdHAjT7fsKaX6XIJn+aQEFiOcE4X8e7VvdMCJ+WDZxjSRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-windows-32": {
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.16.tgz",
+      "integrity": "sha512-zQgWpY5pUCSTOwqKQ6/vOCJfRssTvxFuEkpB4f2VUGPBpdddZfdj8hbZuFRdZRPIVHvN7juGcpgCA/XCF37mAQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-windows-64": {
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.16.tgz",
+      "integrity": "sha512-HjW1hHRLSncnM3MBCP7iquatHVJq9l0S2xxsHHj4yzf4nm9TU4Z7k4NkeMlD/dHQ4jPlQQhwcMvwbJiOefSuZw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild/node_modules/esbuild-windows-arm64": {
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.16.tgz",
+      "integrity": "sha512-oCcUKrJaMn04Vxy9Ekd8x23O8LoU01+4NOkQ2iBToKgnGj5eo1vU9i27NQZ9qC8NFZgnQQZg5oZWAejmbsppNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -1561,9 +2011,9 @@
       }
     },
     "node_modules/firebase-tools": {
-      "version": "11.13.0",
-      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-11.13.0.tgz",
-      "integrity": "sha512-8p3AAG0DtDl/FF7Zaq5C5y2UoyWGvzVOgPDBjI+ZIPqBXdrAUHhQ/tVN+5J0IbtV+YXTyCmxIKf7kcIenzl2Xg==",
+      "version": "11.16.1",
+      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-11.16.1.tgz",
+      "integrity": "sha512-vi8NRUeeBXy7Be+Hk7DK0+ClF+snhjYa5s3fwPRYCGXbCX47E+jreahS6jXJIxeqMbHPmhPZrJXsy7Tdp1Ryug==",
       "dev": true,
       "hasShrinkwrap": true,
       "dependencies": {
@@ -1660,9 +2110,9 @@
       }
     },
     "node_modules/firebase-tools/node_modules/@gar/promisify": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.2.tgz",
-      "integrity": "sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "dev": true,
       "optional": true
     },
@@ -1947,23 +2397,23 @@
       "dev": true
     },
     "node_modules/firebase-tools/node_modules/@npmcli/fs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.0.tgz",
-      "integrity": "sha512-VhP1qZLXcrXRIaPoqb4YA55JQxLNF3jNR4T55IdOJa3+IFJKNYHtPvtXx8slmeMavj37vCzCfrqQM1vWLsYKLA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
+      "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
       "dev": true,
       "optional": true,
       "dependencies": {
-        "@gar/promisify": "^1.0.1",
+        "@gar/promisify": "^1.1.3",
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/firebase-tools/node_modules/@npmcli/fs/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -1977,9 +2427,9 @@
       }
     },
     "node_modules/firebase-tools/node_modules/@npmcli/move-file": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
-      "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
+      "integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -1987,7 +2437,7 @@
         "rimraf": "^3.0.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/firebase-tools/node_modules/@npmcli/move-file/node_modules/mkdirp": {
@@ -2231,9 +2681,9 @@
       "dev": true
     },
     "node_modules/firebase-tools/node_modules/agentkeepalive": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.0.tgz",
-      "integrity": "sha512-0PhAp58jZNw13UJv7NVdTGb0ZcghHUb3DrZ046JiiJY/BOaTTpbwdHq2VObPCBV8M2GPh7sgrJ3AQ8Ey468LJw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
+      "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -2246,9 +2696,9 @@
       }
     },
     "node_modules/firebase-tools/node_modules/agentkeepalive/node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -2378,7 +2828,7 @@
     "node_modules/firebase-tools/node_modules/ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -2471,9 +2921,9 @@
       "dev": true
     },
     "node_modules/firebase-tools/node_modules/are-we-there-yet": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
-      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -2481,7 +2931,7 @@
         "readable-stream": "^3.6.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/firebase-tools/node_modules/argparse": {
@@ -2896,33 +3346,43 @@
       }
     },
     "node_modules/firebase-tools/node_modules/cacache": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
-      "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+      "version": "16.1.3",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
+      "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
       "dev": true,
       "optional": true,
       "dependencies": {
-        "@npmcli/fs": "^1.0.0",
-        "@npmcli/move-file": "^1.0.1",
+        "@npmcli/fs": "^2.1.0",
+        "@npmcli/move-file": "^2.0.0",
         "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "glob": "^7.1.4",
+        "fs-minipass": "^2.1.0",
+        "glob": "^8.0.1",
         "infer-owner": "^1.0.4",
-        "lru-cache": "^6.0.0",
-        "minipass": "^3.1.1",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
         "minipass-collect": "^1.0.2",
         "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.2",
-        "mkdirp": "^1.0.3",
+        "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
         "p-map": "^4.0.0",
         "promise-inflight": "^1.0.1",
         "rimraf": "^3.0.2",
-        "ssri": "^8.0.1",
-        "tar": "^6.0.2",
-        "unique-filename": "^1.1.1"
+        "ssri": "^9.0.0",
+        "tar": "^6.1.11",
+        "unique-filename": "^2.0.0"
       },
       "engines": {
-        "node": ">= 10"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/cacache/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/firebase-tools/node_modules/cacache/node_modules/chownr": {
@@ -2931,6 +3391,49 @@
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
       "dev": true,
       "optional": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/cacache/node_modules/glob": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/cacache/node_modules/lru-cache": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.0.tgz",
+      "integrity": "sha512-EIRtP1GrSJny0dqb50QXRUNBxHJhcpxHC++M5tD7RYbvLLn5KVWKsbyswSSqDuU15UFi3bgTQIY8nhDMeF6aDQ==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/cacache/node_modules/minimatch": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
       "engines": {
         "node": ">=10"
       }
@@ -3311,7 +3814,7 @@
     "node_modules/firebase-tools/node_modules/compare-semver": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/compare-semver/-/compare-semver-1.1.0.tgz",
-      "integrity": "sha1-fAp5onu4C2xplERfgpWCWdPQIVM=",
+      "integrity": "sha512-AENcdfhxsMCzzl+QRdOwMQeA8tZBEEacAmA4pGPoyco27G9sIaM98WNYkcToC9O0wIx1vE+1ErmaM4t0/fXhMw==",
       "dev": true,
       "dependencies": {
         "semver": "^5.0.1"
@@ -3445,7 +3948,7 @@
     "node_modules/firebase-tools/node_modules/console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
       "dev": true,
       "optional": true
     },
@@ -3732,7 +4235,7 @@
     "node_modules/firebase-tools/node_modules/delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
       "dev": true,
       "optional": true
     },
@@ -4526,34 +5029,23 @@
       "dev": true
     },
     "node_modules/firebase-tools/node_modules/gauge": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.0.tgz",
-      "integrity": "sha512-F8sU45yQpjQjxKkm1UOAhf0U/O0aFt//Fl7hsrNVto+patMHjs7dPI9mFOGUKbhrgKm0S3EjW3scMFuQmWSROw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
       "dev": true,
       "optional": true,
       "dependencies": {
-        "ansi-regex": "^5.0.1",
         "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.2",
-        "console-control-strings": "^1.0.0",
+        "color-support": "^1.1.3",
+        "console-control-strings": "^1.1.0",
         "has-unicode": "^2.0.1",
-        "signal-exit": "^3.0.0",
+        "signal-exit": "^3.0.7",
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.2"
+        "wide-align": "^1.1.5"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/gauge/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=8"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/firebase-tools/node_modules/gaxios": {
@@ -4753,16 +5245,25 @@
       }
     },
     "node_modules/firebase-tools/node_modules/global-dirs": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.0.1.tgz",
-      "integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.1.0.tgz",
+      "integrity": "sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==",
       "dev": true,
       "dependencies": {
-        "ini": "^1.3.5"
+        "ini": "1.3.7"
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/firebase-tools/node_modules/global-dirs/node_modules/ini": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
+      "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
+      "dev": true
     },
     "node_modules/firebase-tools/node_modules/google-auth-library": {
       "version": "7.14.1",
@@ -4918,7 +5419,7 @@
     "node_modules/firebase-tools/node_modules/has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
       "dev": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
@@ -4930,7 +5431,7 @@
     "node_modules/firebase-tools/node_modules/has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
       "dev": true,
       "optional": true
     },
@@ -5055,7 +5556,7 @@
     "node_modules/firebase-tools/node_modules/humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -5274,9 +5775,9 @@
       }
     },
     "node_modules/firebase-tools/node_modules/install-artifact-from-github": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/install-artifact-from-github/-/install-artifact-from-github-1.3.0.tgz",
-      "integrity": "sha512-iT8v1GwOAX0pPXifF/5ihnMhHOCo3OeK7z3TQa4CtSNCIg8k0UxqBEk9jRwz8OP68hHXvJ2gxRa89KYHtBkqGA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/install-artifact-from-github/-/install-artifact-from-github-1.3.1.tgz",
+      "integrity": "sha512-3l3Bymg2eKDsN5wQuMfgGEj2x6l5MCAv0zPL6rxHESufFVlEAKW/6oY9F1aGgvY/EgWm5+eWGRjINveL4X7Hgg==",
       "dev": true,
       "optional": true,
       "bin": {
@@ -5390,7 +5891,7 @@
     "node_modules/firebase-tools/node_modules/is-lambda": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-      "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=",
+      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
       "dev": true,
       "optional": true
     },
@@ -6047,37 +6548,47 @@
       }
     },
     "node_modules/firebase-tools/node_modules/make-fetch-happen": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
-      "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
+      "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
       "dev": true,
       "optional": true,
       "dependencies": {
-        "agentkeepalive": "^4.1.3",
-        "cacache": "^15.2.0",
+        "agentkeepalive": "^4.2.1",
+        "cacache": "^16.1.0",
         "http-cache-semantics": "^4.1.0",
-        "http-proxy-agent": "^4.0.1",
+        "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "is-lambda": "^1.0.1",
-        "lru-cache": "^6.0.0",
-        "minipass": "^3.1.3",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
         "minipass-collect": "^1.0.2",
-        "minipass-fetch": "^1.3.2",
+        "minipass-fetch": "^2.0.3",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.2",
+        "negotiator": "^0.6.3",
         "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^6.0.0",
-        "ssri": "^8.0.0"
+        "socks-proxy-agent": "^7.0.0",
+        "ssri": "^9.0.0"
       },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/make-fetch-happen/node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/firebase-tools/node_modules/make-fetch-happen/node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -6092,6 +6603,31 @@
         }
       }
     },
+    "node_modules/firebase-tools/node_modules/make-fetch-happen/node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/firebase-tools/node_modules/make-fetch-happen/node_modules/lru-cache": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.0.tgz",
+      "integrity": "sha512-EIRtP1GrSJny0dqb50QXRUNBxHJhcpxHC++M5tD7RYbvLLn5KVWKsbyswSSqDuU15UFi3bgTQIY8nhDMeF6aDQ==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/firebase-tools/node_modules/make-fetch-happen/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -6099,16 +6635,26 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/firebase-tools/node_modules/make-fetch-happen/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/firebase-tools/node_modules/make-fetch-happen/node_modules/socks-proxy-agent": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
-      "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
       "dev": true,
       "optional": true,
       "dependencies": {
         "agent-base": "^6.0.2",
-        "debug": "^4.3.1",
-        "socks": "^2.6.1"
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
       },
       "engines": {
         "node": ">= 10"
@@ -6277,21 +6823,21 @@
       }
     },
     "node_modules/firebase-tools/node_modules/minipass-fetch": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
-      "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
+      "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
       "dev": true,
       "optional": true,
       "dependencies": {
-        "minipass": "^3.1.0",
+        "minipass": "^3.1.6",
         "minipass-sized": "^1.0.3",
-        "minizlib": "^2.0.0"
+        "minizlib": "^2.1.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       },
       "optionalDependencies": {
-        "encoding": "^0.1.12"
+        "encoding": "^0.1.13"
       }
     },
     "node_modules/firebase-tools/node_modules/minipass-flush": {
@@ -6396,9 +6942,9 @@
       "dev": true
     },
     "node_modules/firebase-tools/node_modules/nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
       "dev": true,
       "optional": true
     },
@@ -6456,16 +7002,16 @@
       }
     },
     "node_modules/firebase-tools/node_modules/node-gyp": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
-      "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.1.0.tgz",
+      "integrity": "sha512-HkmN0ZpQJU7FLbJauJTHkHlSVAXlNGDAzH/VYFZGDOnFyn/Na3GlNJfkudmufOdS6/jNFhy88ObzL7ERz9es1g==",
       "dev": true,
       "optional": true,
       "dependencies": {
         "env-paths": "^2.2.0",
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^9.1.0",
+        "make-fetch-happen": "^10.0.3",
         "nopt": "^5.0.0",
         "npmlog": "^6.0.0",
         "rimraf": "^3.0.2",
@@ -6477,13 +7023,13 @@
         "node-gyp": "bin/node-gyp.js"
       },
       "engines": {
-        "node": ">= 10.12.0"
+        "node": "^12.22 || ^14.13 || >=16"
       }
     },
     "node_modules/firebase-tools/node_modules/node-gyp/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -6547,19 +7093,19 @@
       }
     },
     "node_modules/firebase-tools/node_modules/npmlog": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.0.tgz",
-      "integrity": "sha512-03ppFRGlsyUaQFbGC2C8QWJN/C/K7PsfyD9aQdhVKAQIH4sQBc8WASqFBP7O+Ut4d2oo5LoeoboB3cGdBZSp6Q==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
       "dev": true,
       "optional": true,
       "dependencies": {
-        "are-we-there-yet": "^2.0.0",
+        "are-we-there-yet": "^3.0.0",
         "console-control-strings": "^1.1.0",
-        "gauge": "^4.0.0",
+        "gauge": "^4.0.3",
         "set-blocking": "^2.0.0"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/firebase-tools/node_modules/oauth-sign": {
@@ -7001,7 +7547,7 @@
     "node_modules/firebase-tools/node_modules/promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
       "dev": true,
       "optional": true
     },
@@ -7022,7 +7568,7 @@
     "node_modules/firebase-tools/node_modules/promise-retry/node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
       "dev": true,
       "optional": true,
       "engines": {
@@ -7223,16 +7769,16 @@
       }
     },
     "node_modules/firebase-tools/node_modules/re2": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/re2/-/re2-1.17.3.tgz",
-      "integrity": "sha512-Dp5iWVR8W3C7Nm9DziMY4BleMPRb/pe6kvfbzLv80dVYaXRc9jRnwwNqU0oE/taRm0qYR1+Qrtzk9rPjS9ecaQ==",
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/re2/-/re2-1.17.7.tgz",
+      "integrity": "sha512-X8GSuiBoVWwcjuppqSjsIkRxNUKDdjhkO9SBekQbZ2ksqWUReCy7DQPWOVpoTnpdtdz5PIpTTxTFzvJv5UMfjA==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
-        "install-artifact-from-github": "^1.3.0",
-        "nan": "^2.15.0",
-        "node-gyp": "^8.4.1"
+        "install-artifact-from-github": "^1.3.1",
+        "nan": "^2.16.0",
+        "node-gyp": "^9.0.0"
       }
     },
     "node_modules/firebase-tools/node_modules/readable-stream": {
@@ -7657,13 +8203,13 @@
       }
     },
     "node_modules/firebase-tools/node_modules/socks": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
-      "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.0.tgz",
+      "integrity": "sha512-scnOe9y4VuiNUULJN72GrM26BNOjVsfPXI+j+98PkyEfsIXroa5ofyjT+FzGvn/xHs73U2JtoBYAVx9Hl4quSA==",
       "dev": true,
       "dependencies": {
-        "ip": "^1.1.5",
-        "smart-buffer": "^4.1.0"
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
       },
       "engines": {
         "node": ">= 10.13.0",
@@ -7705,6 +8251,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/firebase-tools/node_modules/socks/node_modules/ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
       "dev": true
     },
     "node_modules/firebase-tools/node_modules/source-map": {
@@ -7749,16 +8301,16 @@
       }
     },
     "node_modules/firebase-tools/node_modules/ssri": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
-      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
+      "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
       "dev": true,
       "optional": true,
       "dependencies": {
         "minipass": "^3.1.1"
       },
       "engines": {
-        "node": ">= 8"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/firebase-tools/node_modules/stack-trace": {
@@ -7812,7 +8364,7 @@
     "node_modules/firebase-tools/node_modules/string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
-      "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
+      "integrity": "sha512-MNCACnufWUf3pQ57O5WTBMkKhzYIaKEcUioO0XHrTMafrbBaNk4IyDOLHBv5xbXO0jLLdsYWeFjpjG2hVHRDtw==",
       "dev": true,
       "dependencies": {
         "strip-ansi": "^3.0.0"
@@ -7824,7 +8376,7 @@
     "node_modules/firebase-tools/node_modules/string-length/node_modules/strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "dev": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
@@ -7918,7 +8470,7 @@
     "node_modules/firebase-tools/node_modules/superstatic/node_modules/ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -7927,7 +8479,7 @@
     "node_modules/firebase-tools/node_modules/superstatic/node_modules/chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
       "dev": true,
       "dependencies": {
         "ansi-styles": "^2.2.1",
@@ -7959,9 +8511,9 @@
       "dev": true
     },
     "node_modules/firebase-tools/node_modules/superstatic/node_modules/commander": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
-      "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
+      "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
       "dev": true,
       "engines": {
         "node": "^12.20.0 || >=14"
@@ -7994,7 +8546,7 @@
     "node_modules/firebase-tools/node_modules/superstatic/node_modules/strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "dev": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
@@ -8006,7 +8558,7 @@
     "node_modules/firebase-tools/node_modules/superstatic/node_modules/supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
@@ -8371,23 +8923,29 @@
       }
     },
     "node_modules/firebase-tools/node_modules/unique-filename": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
+      "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
       "dev": true,
       "optional": true,
       "dependencies": {
-        "unique-slug": "^2.0.0"
+        "unique-slug": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/firebase-tools/node_modules/unique-slug": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
-      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
+      "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
       "dev": true,
       "optional": true,
       "dependencies": {
         "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/firebase-tools/node_modules/universal-analytics": {
@@ -9203,6 +9761,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/http-parser-js": {
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
@@ -9390,18 +9957,6 @@
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
@@ -9420,6 +9975,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/muggle-string": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.1.0.tgz",
+      "integrity": "sha512-Tr1knR3d2mKvvWthlk7202rywKbiOm4rVFLsfAaSIhJ6dt9o47W4S+JMtWhd/PW9Wrdew2/S2fSvhz3E2gkfEg==",
+      "dev": true
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
@@ -9583,9 +10144,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
-      "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+      "version": "8.4.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
+      "integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
       "funding": [
         {
           "type": "opencollective",
@@ -9743,9 +10304,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.78.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
-      "integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
+      "version": "2.79.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -9790,21 +10351,6 @@
       },
       "engines": {
         "node": ">= 10.15.0"
-      }
-    },
-    "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/setimmediate": {
@@ -9929,15 +10475,15 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/vite": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-3.1.3.tgz",
-      "integrity": "sha512-/3XWiktaopByM5bd8dqvHxRt5EEgRikevnnrpND0gRfNkrMrPaGGexhtLCzv15RcCMtV2CLw+BPas8YFeSG0KA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.4.tgz",
+      "integrity": "sha512-Z2X6SRAffOUYTa+sLy3NQ7nlHFU100xwanq1WDwqaiFiCe+25zdxP1TfCS5ojPV2oDDcXudHIoPnI1Z/66B7Yw==",
       "dev": true,
       "dependencies": {
-        "esbuild": "^0.15.6",
-        "postcss": "^8.4.16",
+        "esbuild": "^0.15.9",
+        "postcss": "^8.4.18",
         "resolve": "^1.22.1",
-        "rollup": "~2.78.0"
+        "rollup": "^2.79.1"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -9949,12 +10495,17 @@
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
+        "@types/node": ">= 14",
         "less": "*",
         "sass": "*",
         "stylus": "*",
+        "sugarss": "*",
         "terser": "^5.4.0"
       },
       "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
         "less": {
           "optional": true
         },
@@ -9962,6 +10513,9 @@
           "optional": true
         },
         "stylus": {
+          "optional": true
+        },
+        "sugarss": {
           "optional": true
         },
         "terser": {
@@ -9995,14 +10549,24 @@
         "vue": "^3.2.0"
       }
     },
-    "node_modules/vue-tsc": {
-      "version": "0.39.5",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-0.39.5.tgz",
-      "integrity": "sha512-jhTsrKhZkafpIeN4Cbhr1K53hNfa/oesSrlh7hUaeHyCk55VhZT6oJkwJbtqN4MYkWZIwPrm3/xTwsELuf2ocg==",
+    "node_modules/vue-template-compiler": {
+      "version": "2.7.14",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
+      "integrity": "sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==",
       "dev": true,
       "dependencies": {
-        "@volar/vue-language-core": "0.39.5",
-        "@volar/vue-typescript": "0.39.5"
+        "de-indent": "^1.0.2",
+        "he": "^1.2.0"
+      }
+    },
+    "node_modules/vue-tsc": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.0.10.tgz",
+      "integrity": "sha512-o6ek6ZSDwpVWn7/ZXlIILfCZ18o7ypEYKMDynsyPj9m10/ALXkCLKIj9yVfx00QAX5Z/hKrdhYcA2ZaQ0+U7Kg==",
+      "dev": true,
+      "dependencies": {
+        "@volar/vue-language-core": "1.0.10",
+        "@volar/vue-typescript": "1.0.10"
       },
       "bin": {
         "vue-tsc": "bin/vue-tsc.js"
@@ -10094,12 +10658,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/yargs": {
       "version": "16.2.0",
@@ -10718,65 +11276,174 @@
       "dev": true,
       "requires": {}
     },
-    "@volar/code-gen": {
-      "version": "0.39.5",
-      "resolved": "https://registry.npmjs.org/@volar/code-gen/-/code-gen-0.39.5.tgz",
-      "integrity": "sha512-vQr5VoCH8T2NHmqLc/AA1/4F8l41WB+24+I+VjxBaev/Hmwjye9K0GlmMHAOl84WB3hWGOqpHaPX6JkqzRNjJg==",
+    "@volar/language-core": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.0.10.tgz",
+      "integrity": "sha512-7WNzjvdUXjggEZvYu9EInABl4mvXtyiiaJDOJM+plHJT7xW5voLja0BrYYji6TUn8Q4HakLvTPpQddPLq134mg==",
       "dev": true,
       "requires": {
-        "@volar/source-map": "0.39.5"
+        "@volar/source-map": "1.0.10",
+        "@vue/reactivity": "^3.2.45",
+        "muggle-string": "^0.1.0"
+      },
+      "dependencies": {
+        "@vue/reactivity": {
+          "version": "3.2.45",
+          "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.45.tgz",
+          "integrity": "sha512-PRvhCcQcyEVohW0P8iQ7HDcIOXRjZfAsOds3N99X/Dzewy8TVhTCT4uXpAHfoKjVTJRA0O0K+6QNkDIZAxNi3A==",
+          "dev": true,
+          "requires": {
+            "@vue/shared": "3.2.45"
+          }
+        },
+        "@vue/shared": {
+          "version": "3.2.45",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.45.tgz",
+          "integrity": "sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg==",
+          "dev": true
+        }
       }
     },
     "@volar/source-map": {
-      "version": "0.39.5",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-0.39.5.tgz",
-      "integrity": "sha512-IVOX+v++Sr5Kok4/cLbDJp2vf1ia1rChpV7adgcnMle6uORBuGFEur234UzamK0iHRCcfFFRz7z+hSPf2CO23Q==",
-      "dev": true
-    },
-    "@volar/typescript-faster": {
-      "version": "0.39.5",
-      "resolved": "https://registry.npmjs.org/@volar/typescript-faster/-/typescript-faster-0.39.5.tgz",
-      "integrity": "sha512-IzLqlxefmKkjNKXC/8aFiqPcTqnj6RG31D2f9cIWxmW9pvUYJxLED+y9phnOxNxq0OmeRtQ3Pfmvu85tUBoZsQ==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.0.10.tgz",
+      "integrity": "sha512-jSZW1tfsvAOHlpoRy14zH9sdCYR4g8QcnCXRli8juFC2UHoVzVRKB6VdnXcx5wRAlIRXoiBpsU+pKminryKEBw==",
       "dev": true,
       "requires": {
-        "semver": "^7.3.7"
+        "muggle-string": "^0.1.0"
       }
     },
-    "@volar/vue-code-gen": {
-      "version": "0.39.5",
-      "resolved": "https://registry.npmjs.org/@volar/vue-code-gen/-/vue-code-gen-0.39.5.tgz",
-      "integrity": "sha512-y+QUV9MuuasiIuRoGKQl+gMhDaAX6XNhckAyJCvD1FZ8f2eJuPY2VtoFxmu/Z2bGWBdtUW/g98jaeKJ+j3wwOw==",
+    "@volar/typescript": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.0.10.tgz",
+      "integrity": "sha512-Nd+u2Z2P1V+KiNBMLLK6wV4sswOOYBsjEHmgK29eENXtos1+gF2GWB908vvwmT75dmCtlYZ8No14lvCqXUAVdg==",
       "dev": true,
       "requires": {
-        "@volar/code-gen": "0.39.5",
-        "@volar/source-map": "0.39.5",
-        "@vue/compiler-core": "^3.2.37",
-        "@vue/compiler-dom": "^3.2.37",
-        "@vue/shared": "^3.2.37"
+        "@volar/language-core": "1.0.10"
       }
     },
     "@volar/vue-language-core": {
-      "version": "0.39.5",
-      "resolved": "https://registry.npmjs.org/@volar/vue-language-core/-/vue-language-core-0.39.5.tgz",
-      "integrity": "sha512-m+e1tYuL/WRPhSeC7hZ0NuSwHsfnnGJVxCBHLaP7jR0f6xcC0DAegP3QF+gfu9ZJFPGznpZYFKadngMjuhQS9Q==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@volar/vue-language-core/-/vue-language-core-1.0.10.tgz",
+      "integrity": "sha512-m7pYXGwkpF9Bmuud73kGlAX31QUTwifYbgCenaqm3hGNh+SJebSkxzk4NJvabiGbA6ON3b5ayQZ/rbOEtdoghw==",
       "dev": true,
       "requires": {
-        "@volar/code-gen": "0.39.5",
-        "@volar/source-map": "0.39.5",
-        "@volar/vue-code-gen": "0.39.5",
-        "@vue/compiler-sfc": "^3.2.37",
-        "@vue/reactivity": "^3.2.37"
+        "@volar/language-core": "1.0.10",
+        "@volar/source-map": "1.0.10",
+        "@vue/compiler-dom": "^3.2.45",
+        "@vue/compiler-sfc": "^3.2.45",
+        "@vue/reactivity": "^3.2.45",
+        "@vue/shared": "^3.2.45",
+        "minimatch": "^5.1.0",
+        "vue-template-compiler": "^2.7.14"
+      },
+      "dependencies": {
+        "@vue/compiler-core": {
+          "version": "3.2.45",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.45.tgz",
+          "integrity": "sha512-rcMj7H+PYe5wBV3iYeUgbCglC+pbpN8hBLTJvRiK2eKQiWqu+fG9F+8sW99JdL4LQi7Re178UOxn09puSXvn4A==",
+          "dev": true,
+          "requires": {
+            "@babel/parser": "^7.16.4",
+            "@vue/shared": "3.2.45",
+            "estree-walker": "^2.0.2",
+            "source-map": "^0.6.1"
+          }
+        },
+        "@vue/compiler-dom": {
+          "version": "3.2.45",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.45.tgz",
+          "integrity": "sha512-tyYeUEuKqqZO137WrZkpwfPCdiiIeXYCcJ8L4gWz9vqaxzIQRccTSwSWZ/Axx5YR2z+LvpUbmPNXxuBU45lyRw==",
+          "dev": true,
+          "requires": {
+            "@vue/compiler-core": "3.2.45",
+            "@vue/shared": "3.2.45"
+          }
+        },
+        "@vue/compiler-sfc": {
+          "version": "3.2.45",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.45.tgz",
+          "integrity": "sha512-1jXDuWah1ggsnSAOGsec8cFjT/K6TMZ0sPL3o3d84Ft2AYZi2jWJgRMjw4iaK0rBfA89L5gw427H4n1RZQBu6Q==",
+          "dev": true,
+          "requires": {
+            "@babel/parser": "^7.16.4",
+            "@vue/compiler-core": "3.2.45",
+            "@vue/compiler-dom": "3.2.45",
+            "@vue/compiler-ssr": "3.2.45",
+            "@vue/reactivity-transform": "3.2.45",
+            "@vue/shared": "3.2.45",
+            "estree-walker": "^2.0.2",
+            "magic-string": "^0.25.7",
+            "postcss": "^8.1.10",
+            "source-map": "^0.6.1"
+          }
+        },
+        "@vue/compiler-ssr": {
+          "version": "3.2.45",
+          "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.45.tgz",
+          "integrity": "sha512-6BRaggEGqhWht3lt24CrIbQSRD5O07MTmd+LjAn5fJj568+R9eUD2F7wMQJjX859seSlrYog7sUtrZSd7feqrQ==",
+          "dev": true,
+          "requires": {
+            "@vue/compiler-dom": "3.2.45",
+            "@vue/shared": "3.2.45"
+          }
+        },
+        "@vue/reactivity": {
+          "version": "3.2.45",
+          "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.45.tgz",
+          "integrity": "sha512-PRvhCcQcyEVohW0P8iQ7HDcIOXRjZfAsOds3N99X/Dzewy8TVhTCT4uXpAHfoKjVTJRA0O0K+6QNkDIZAxNi3A==",
+          "dev": true,
+          "requires": {
+            "@vue/shared": "3.2.45"
+          }
+        },
+        "@vue/reactivity-transform": {
+          "version": "3.2.45",
+          "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.45.tgz",
+          "integrity": "sha512-BHVmzYAvM7vcU5WmuYqXpwaBHjsS8T63jlKGWVtHxAHIoMIlmaMyurUSEs1Zcg46M4AYT5MtB1U274/2aNzjJQ==",
+          "dev": true,
+          "requires": {
+            "@babel/parser": "^7.16.4",
+            "@vue/compiler-core": "3.2.45",
+            "@vue/shared": "3.2.45",
+            "estree-walker": "^2.0.2",
+            "magic-string": "^0.25.7"
+          }
+        },
+        "@vue/shared": {
+          "version": "3.2.45",
+          "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.45.tgz",
+          "integrity": "sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg==",
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
+          "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "@volar/vue-typescript": {
-      "version": "0.39.5",
-      "resolved": "https://registry.npmjs.org/@volar/vue-typescript/-/vue-typescript-0.39.5.tgz",
-      "integrity": "sha512-ckhWD1xOi0OMr702XVkv/Npsb9FKAp5gvhxyLv0QqWekPdSo04t4KrZfwosJLGERIEcyr50SuB7HqBp8ndQmzA==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@volar/vue-typescript/-/vue-typescript-1.0.10.tgz",
+      "integrity": "sha512-GjQ+mfIUljXGfkTmNrfNT8YYQY48mcOE5SJ190o6ENArzH9cqjmvPLo1nrdurbZOFwztwEDNye5N1/5aL9sZ1g==",
       "dev": true,
       "requires": {
-        "@volar/code-gen": "0.39.5",
-        "@volar/typescript-faster": "0.39.5",
-        "@volar/vue-language-core": "0.39.5"
+        "@volar/typescript": "1.0.10",
+        "@volar/vue-language-core": "1.0.10"
       }
     },
     "@vue/compiler-core": {
@@ -11008,6 +11675,12 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
       "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
     },
+    "de-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
+      "dev": true
+    },
     "deep-equal": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
@@ -11036,33 +11709,182 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "esbuild": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.8.tgz",
-      "integrity": "sha512-Remsk2dmr1Ia65sU+QasE6svJbsHe62lzR+CnjpUvbZ+uSYo1SitiOWPRfZQkCu82YWZBBKXiD/j0i//XWMZ+Q==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.16.tgz",
+      "integrity": "sha512-o6iS9zxdHrrojjlj6pNGC2NAg86ECZqIETswTM5KmJitq+R1YmahhWtMumeQp9lHqJaROGnsBi2RLawGnfo5ZQ==",
       "dev": true,
       "requires": {
-        "@esbuild/android-arm": "0.15.8",
-        "@esbuild/linux-loong64": "0.15.8",
-        "esbuild-android-64": "0.15.8",
-        "esbuild-android-arm64": "0.15.8",
-        "esbuild-darwin-64": "0.15.8",
-        "esbuild-darwin-arm64": "0.15.8",
-        "esbuild-freebsd-64": "0.15.8",
-        "esbuild-freebsd-arm64": "0.15.8",
-        "esbuild-linux-32": "0.15.8",
-        "esbuild-linux-64": "0.15.8",
-        "esbuild-linux-arm": "0.15.8",
-        "esbuild-linux-arm64": "0.15.8",
-        "esbuild-linux-mips64le": "0.15.8",
-        "esbuild-linux-ppc64le": "0.15.8",
-        "esbuild-linux-riscv64": "0.15.8",
-        "esbuild-linux-s390x": "0.15.8",
-        "esbuild-netbsd-64": "0.15.8",
-        "esbuild-openbsd-64": "0.15.8",
-        "esbuild-sunos-64": "0.15.8",
-        "esbuild-windows-32": "0.15.8",
-        "esbuild-windows-64": "0.15.8",
-        "esbuild-windows-arm64": "0.15.8"
+        "@esbuild/android-arm": "0.15.16",
+        "@esbuild/linux-loong64": "0.15.16",
+        "esbuild-android-64": "0.15.16",
+        "esbuild-android-arm64": "0.15.16",
+        "esbuild-darwin-64": "0.15.16",
+        "esbuild-darwin-arm64": "0.15.16",
+        "esbuild-freebsd-64": "0.15.16",
+        "esbuild-freebsd-arm64": "0.15.16",
+        "esbuild-linux-32": "0.15.16",
+        "esbuild-linux-64": "0.15.16",
+        "esbuild-linux-arm": "0.15.16",
+        "esbuild-linux-arm64": "0.15.16",
+        "esbuild-linux-mips64le": "0.15.16",
+        "esbuild-linux-ppc64le": "0.15.16",
+        "esbuild-linux-riscv64": "0.15.16",
+        "esbuild-linux-s390x": "0.15.16",
+        "esbuild-netbsd-64": "0.15.16",
+        "esbuild-openbsd-64": "0.15.16",
+        "esbuild-sunos-64": "0.15.16",
+        "esbuild-windows-32": "0.15.16",
+        "esbuild-windows-64": "0.15.16",
+        "esbuild-windows-arm64": "0.15.16"
+      },
+      "dependencies": {
+        "@esbuild/android-arm": {
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.16.tgz",
+          "integrity": "sha512-nyB6CH++2mSgx3GbnrJsZSxzne5K0HMyNIWafDHqYy7IwxFc4fd/CgHVZXr8Eh+Q3KbIAcAe3vGyqIPhGblvMQ==",
+          "dev": true,
+          "optional": true
+        },
+        "@esbuild/linux-loong64": {
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.16.tgz",
+          "integrity": "sha512-SDLfP1uoB0HZ14CdVYgagllgrG7Mdxhkt4jDJOKl/MldKrkQ6vDJMZKl2+5XsEY/Lzz37fjgLQoJBGuAw/x8kQ==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-android-64": {
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.16.tgz",
+          "integrity": "sha512-Vwkv/sT0zMSgPSVO3Jlt1pUbnZuOgtOQJkJkyyJFAlLe7BiT8e9ESzo0zQSx4c3wW4T6kGChmKDPMbWTgtliQA==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-android-arm64": {
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.16.tgz",
+          "integrity": "sha512-lqfKuofMExL5niNV3gnhMUYacSXfsvzTa/58sDlBET/hCOG99Zmeh+lz6kvdgvGOsImeo6J9SW21rFCogNPLxg==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-darwin-arm64": {
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.16.tgz",
+          "integrity": "sha512-fMXaUr5ou0M4WnewBKsspMtX++C1yIa3nJ5R2LSbLCfJT3uFdcRoU/NZjoM4kOMKyOD9Sa/2vlgN8G07K3SJnw==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-freebsd-64": {
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.16.tgz",
+          "integrity": "sha512-UzIc0xlRx5x9kRuMr+E3+hlSOxa/aRqfuMfiYBXu2jJ8Mzej4lGL7+o6F5hzhLqWfWm1GWHNakIdlqg1ayaTNQ==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-freebsd-arm64": {
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.16.tgz",
+          "integrity": "sha512-8xyiYuGc0DLZphFQIiYaLHlfoP+hAN9RHbE+Ibh8EUcDNHAqbQgUrQg7pE7Bo00rXmQ5Ap6KFgcR0b4ALZls1g==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-linux-32": {
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.16.tgz",
+          "integrity": "sha512-iGijUTV+0kIMyUVoynK0v+32Oi8yyp0xwMzX69GX+5+AniNy/C/AL1MjFTsozRp/3xQPl7jVux/PLe2ds10/2w==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-linux-64": {
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.16.tgz",
+          "integrity": "sha512-tuSOjXdLw7VzaUj89fIdAaQT7zFGbKBcz4YxbWrOiXkwscYgE7HtTxUavreBbnRkGxKwr9iT/gmeJWNm4djy/g==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-linux-arm": {
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.16.tgz",
+          "integrity": "sha512-XKcrxCEXDTOuoRj5l12tJnkvuxXBMKwEC5j0JISw3ziLf0j4zIwXbKbTmUrKFWbo6ZgvNpa7Y5dnbsjVvH39bQ==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-linux-arm64": {
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.16.tgz",
+          "integrity": "sha512-mPYksnfHnemNrvjrDhZyixL/AfbJN0Xn9S34ZOHYdh6/jJcNd8iTsv3JwJoEvTJqjMggjMhGUPJAdjnFBHoH8A==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-linux-mips64le": {
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.16.tgz",
+          "integrity": "sha512-kSJO2PXaxfm0pWY39+YX+QtpFqyyrcp0ZeI8QPTrcFVQoWEPiPVtOfTZeS3ZKedfH+Ga38c4DSzmKMQJocQv6A==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-linux-ppc64le": {
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.16.tgz",
+          "integrity": "sha512-NimPikwkBY0yGABw6SlhKrtT35sU4O23xkhlrTT/O6lSxv3Pm5iSc6OYaqVAHWkLdVf31bF4UDVFO+D990WpAA==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-linux-riscv64": {
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.16.tgz",
+          "integrity": "sha512-ty2YUHZlwFOwp7pR+J87M4CVrXJIf5ZZtU/umpxgVJBXvWjhziSLEQxvl30SYfUPq0nzeWKBGw5i/DieiHeKfw==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-linux-s390x": {
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.16.tgz",
+          "integrity": "sha512-VkZaGssvPDQtx4fvVdZ9czezmyWyzpQhEbSNsHZZN0BHvxRLOYAQ7sjay8nMQwYswP6O2KlZluRMNPYefFRs+w==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-netbsd-64": {
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.16.tgz",
+          "integrity": "sha512-ElQ9rhdY51et6MJTWrCPbqOd/YuPowD7Cxx3ee8wlmXQQVW7UvQI6nSprJ9uVFQISqSF5e5EWpwWqXZsECLvXg==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-openbsd-64": {
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.16.tgz",
+          "integrity": "sha512-KgxMHyxMCT+NdLQE1zVJEsLSt2QQBAvJfmUGDmgEq8Fvjrf6vSKB00dVHUEDKcJwMID6CdgCpvYNt999tIYhqA==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-sunos-64": {
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.16.tgz",
+          "integrity": "sha512-exSAx8Phj7QylXHlMfIyEfNrmqnLxFqLxdQF6MBHPdHAjT7fsKaX6XIJn+aQEFiOcE4X8e7VvdMCJ+WDZxjSRQ==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-windows-32": {
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.16.tgz",
+          "integrity": "sha512-zQgWpY5pUCSTOwqKQ6/vOCJfRssTvxFuEkpB4f2VUGPBpdddZfdj8hbZuFRdZRPIVHvN7juGcpgCA/XCF37mAQ==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-windows-64": {
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.16.tgz",
+          "integrity": "sha512-HjW1hHRLSncnM3MBCP7iquatHVJq9l0S2xxsHHj4yzf4nm9TU4Z7k4NkeMlD/dHQ4jPlQQhwcMvwbJiOefSuZw==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-windows-arm64": {
+          "version": "0.15.16",
+          "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.16.tgz",
+          "integrity": "sha512-oCcUKrJaMn04Vxy9Ekd8x23O8LoU01+4NOkQ2iBToKgnGj5eo1vU9i27NQZ9qC8NFZgnQQZg5oZWAejmbsppNA==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "esbuild-android-64": {
@@ -11083,9 +11905,9 @@
       "optional": true
     },
     "esbuild-darwin-64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.8.tgz",
-      "integrity": "sha512-KaKcGfJ+yto7Fo5gAj3xwxHMd1fBIKatpCHK8znTJLVv+9+NN2/tIPBqA4w5rBwjX0UqXDeIE2v1xJP+nGEXgA==",
+      "version": "0.15.16",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.16.tgz",
+      "integrity": "sha512-wo2VWk/n/9V2TmqUZ/KpzRjCEcr00n7yahEdmtzlrfQ3lfMCf3Wa+0sqHAbjk3C6CKkR3WKK/whkMq5Gj4Da9g==",
       "dev": true,
       "optional": true
     },
@@ -11291,9 +12113,9 @@
       }
     },
     "firebase-tools": {
-      "version": "11.13.0",
-      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-11.13.0.tgz",
-      "integrity": "sha512-8p3AAG0DtDl/FF7Zaq5C5y2UoyWGvzVOgPDBjI+ZIPqBXdrAUHhQ/tVN+5J0IbtV+YXTyCmxIKf7kcIenzl2Xg==",
+      "version": "11.16.1",
+      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-11.16.1.tgz",
+      "integrity": "sha512-vi8NRUeeBXy7Be+Hk7DK0+ClF+snhjYa5s3fwPRYCGXbCX47E+jreahS6jXJIxeqMbHPmhPZrJXsy7Tdp1Ryug==",
       "dev": true,
       "requires": {
         "@google-cloud/pubsub": "^3.0.1",
@@ -11378,9 +12200,9 @@
           "optional": true
         },
         "@gar/promisify": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.2.tgz",
-          "integrity": "sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+          "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
           "dev": true,
           "optional": true
         },
@@ -11604,20 +12426,20 @@
           "dev": true
         },
         "@npmcli/fs": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.0.tgz",
-          "integrity": "sha512-VhP1qZLXcrXRIaPoqb4YA55JQxLNF3jNR4T55IdOJa3+IFJKNYHtPvtXx8slmeMavj37vCzCfrqQM1vWLsYKLA==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
+          "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
           "dev": true,
           "optional": true,
           "requires": {
-            "@gar/promisify": "^1.0.1",
+            "@gar/promisify": "^1.1.3",
             "semver": "^7.3.5"
           },
           "dependencies": {
             "semver": {
-              "version": "7.3.5",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-              "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+              "version": "7.3.7",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+              "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -11627,9 +12449,9 @@
           }
         },
         "@npmcli/move-file": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
-          "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
+          "integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -11835,9 +12657,9 @@
           }
         },
         "agentkeepalive": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.0.tgz",
-          "integrity": "sha512-0PhAp58jZNw13UJv7NVdTGb0ZcghHUb3DrZ046JiiJY/BOaTTpbwdHq2VObPCBV8M2GPh7sgrJ3AQ8Ey468LJw==",
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
+          "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -11847,9 +12669,9 @@
           },
           "dependencies": {
             "debug": {
-              "version": "4.3.3",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-              "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+              "version": "4.3.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+              "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -11946,7 +12768,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
           "dev": true
         },
         "ansicolors": {
@@ -12031,9 +12853,9 @@
           }
         },
         "are-we-there-yet": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
-          "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+          "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -12360,38 +13182,79 @@
           "dev": true
         },
         "cacache": {
-          "version": "15.3.0",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
-          "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+          "version": "16.1.3",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
+          "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
           "dev": true,
           "optional": true,
           "requires": {
-            "@npmcli/fs": "^1.0.0",
-            "@npmcli/move-file": "^1.0.1",
+            "@npmcli/fs": "^2.1.0",
+            "@npmcli/move-file": "^2.0.0",
             "chownr": "^2.0.0",
-            "fs-minipass": "^2.0.0",
-            "glob": "^7.1.4",
+            "fs-minipass": "^2.1.0",
+            "glob": "^8.0.1",
             "infer-owner": "^1.0.4",
-            "lru-cache": "^6.0.0",
-            "minipass": "^3.1.1",
+            "lru-cache": "^7.7.1",
+            "minipass": "^3.1.6",
             "minipass-collect": "^1.0.2",
             "minipass-flush": "^1.0.5",
-            "minipass-pipeline": "^1.2.2",
-            "mkdirp": "^1.0.3",
+            "minipass-pipeline": "^1.2.4",
+            "mkdirp": "^1.0.4",
             "p-map": "^4.0.0",
             "promise-inflight": "^1.0.1",
             "rimraf": "^3.0.2",
-            "ssri": "^8.0.1",
-            "tar": "^6.0.2",
-            "unique-filename": "^1.1.1"
+            "ssri": "^9.0.0",
+            "tar": "^6.1.11",
+            "unique-filename": "^2.0.0"
           },
           "dependencies": {
+            "brace-expansion": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+              "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "balanced-match": "^1.0.0"
+              }
+            },
             "chownr": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
               "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
               "dev": true,
               "optional": true
+            },
+            "glob": {
+              "version": "8.0.3",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+              "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^5.0.1",
+                "once": "^1.3.0"
+              }
+            },
+            "lru-cache": {
+              "version": "7.14.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.0.tgz",
+              "integrity": "sha512-EIRtP1GrSJny0dqb50QXRUNBxHJhcpxHC++M5tD7RYbvLLn5KVWKsbyswSSqDuU15UFi3bgTQIY8nhDMeF6aDQ==",
+              "dev": true,
+              "optional": true
+            },
+            "minimatch": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+              "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "brace-expansion": "^2.0.1"
+              }
             },
             "mkdirp": {
               "version": "1.0.4",
@@ -12685,7 +13548,7 @@
         "compare-semver": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/compare-semver/-/compare-semver-1.1.0.tgz",
-          "integrity": "sha1-fAp5onu4C2xplERfgpWCWdPQIVM=",
+          "integrity": "sha512-AENcdfhxsMCzzl+QRdOwMQeA8tZBEEacAmA4pGPoyco27G9sIaM98WNYkcToC9O0wIx1vE+1ErmaM4t0/fXhMw==",
           "dev": true,
           "requires": {
             "semver": "^5.0.1"
@@ -12796,7 +13659,7 @@
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
           "dev": true,
           "optional": true
         },
@@ -13020,7 +13883,7 @@
         "delegates": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+          "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
           "dev": true,
           "optional": true
         },
@@ -13678,30 +14541,20 @@
           }
         },
         "gauge": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.0.tgz",
-          "integrity": "sha512-F8sU45yQpjQjxKkm1UOAhf0U/O0aFt//Fl7hsrNVto+patMHjs7dPI9mFOGUKbhrgKm0S3EjW3scMFuQmWSROw==",
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+          "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
           "dev": true,
           "optional": true,
           "requires": {
-            "ansi-regex": "^5.0.1",
             "aproba": "^1.0.3 || ^2.0.0",
-            "color-support": "^1.1.2",
-            "console-control-strings": "^1.0.0",
+            "color-support": "^1.1.3",
+            "console-control-strings": "^1.1.0",
             "has-unicode": "^2.0.1",
-            "signal-exit": "^3.0.0",
+            "signal-exit": "^3.0.7",
             "string-width": "^4.2.3",
             "strip-ansi": "^6.0.1",
-            "wide-align": "^1.1.2"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-              "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-              "dev": true,
-              "optional": true
-            }
+            "wide-align": "^1.1.5"
           }
         },
         "gaxios": {
@@ -13863,12 +14716,20 @@
           }
         },
         "global-dirs": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.0.1.tgz",
-          "integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.1.0.tgz",
+          "integrity": "sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==",
           "dev": true,
           "requires": {
-            "ini": "^1.3.5"
+            "ini": "1.3.7"
+          },
+          "dependencies": {
+            "ini": {
+              "version": "1.3.7",
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
+              "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
+              "dev": true
+            }
           }
         },
         "google-auth-library": {
@@ -14006,7 +14867,7 @@
         "has-ansi": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -14015,7 +14876,7 @@
         "has-unicode": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+          "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
           "dev": true,
           "optional": true
         },
@@ -14121,7 +14982,7 @@
         "humanize-ms": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-          "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+          "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -14280,9 +15141,9 @@
           }
         },
         "install-artifact-from-github": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/install-artifact-from-github/-/install-artifact-from-github-1.3.0.tgz",
-          "integrity": "sha512-iT8v1GwOAX0pPXifF/5ihnMhHOCo3OeK7z3TQa4CtSNCIg8k0UxqBEk9jRwz8OP68hHXvJ2gxRa89KYHtBkqGA==",
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/install-artifact-from-github/-/install-artifact-from-github-1.3.1.tgz",
+          "integrity": "sha512-3l3Bymg2eKDsN5wQuMfgGEj2x6l5MCAv0zPL6rxHESufFVlEAKW/6oY9F1aGgvY/EgWm5+eWGRjINveL4X7Hgg==",
           "dev": true,
           "optional": true
         },
@@ -14362,7 +15223,7 @@
         "is-lambda": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-          "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=",
+          "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
           "dev": true,
           "optional": true
         },
@@ -14932,39 +15793,65 @@
           }
         },
         "make-fetch-happen": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
-          "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+          "version": "10.2.1",
+          "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
+          "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
           "dev": true,
           "optional": true,
           "requires": {
-            "agentkeepalive": "^4.1.3",
-            "cacache": "^15.2.0",
+            "agentkeepalive": "^4.2.1",
+            "cacache": "^16.1.0",
             "http-cache-semantics": "^4.1.0",
-            "http-proxy-agent": "^4.0.1",
+            "http-proxy-agent": "^5.0.0",
             "https-proxy-agent": "^5.0.0",
             "is-lambda": "^1.0.1",
-            "lru-cache": "^6.0.0",
-            "minipass": "^3.1.3",
+            "lru-cache": "^7.7.1",
+            "minipass": "^3.1.6",
             "minipass-collect": "^1.0.2",
-            "minipass-fetch": "^1.3.2",
+            "minipass-fetch": "^2.0.3",
             "minipass-flush": "^1.0.5",
             "minipass-pipeline": "^1.2.4",
-            "negotiator": "^0.6.2",
+            "negotiator": "^0.6.3",
             "promise-retry": "^2.0.1",
-            "socks-proxy-agent": "^6.0.0",
-            "ssri": "^8.0.0"
+            "socks-proxy-agent": "^7.0.0",
+            "ssri": "^9.0.0"
           },
           "dependencies": {
+            "@tootallnate/once": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+              "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+              "dev": true,
+              "optional": true
+            },
             "debug": {
-              "version": "4.3.3",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-              "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+              "version": "4.3.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+              "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
               "dev": true,
               "optional": true,
               "requires": {
                 "ms": "2.1.2"
               }
+            },
+            "http-proxy-agent": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+              "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "@tootallnate/once": "2",
+                "agent-base": "6",
+                "debug": "4"
+              }
+            },
+            "lru-cache": {
+              "version": "7.14.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.0.tgz",
+              "integrity": "sha512-EIRtP1GrSJny0dqb50QXRUNBxHJhcpxHC++M5tD7RYbvLLn5KVWKsbyswSSqDuU15UFi3bgTQIY8nhDMeF6aDQ==",
+              "dev": true,
+              "optional": true
             },
             "ms": {
               "version": "2.1.2",
@@ -14973,16 +15860,23 @@
               "dev": true,
               "optional": true
             },
+            "negotiator": {
+              "version": "0.6.3",
+              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+              "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+              "dev": true,
+              "optional": true
+            },
             "socks-proxy-agent": {
-              "version": "6.1.1",
-              "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
-              "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
+              "version": "7.0.0",
+              "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
+              "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
               "dev": true,
               "optional": true,
               "requires": {
                 "agent-base": "^6.0.2",
-                "debug": "^4.3.1",
-                "socks": "^2.6.1"
+                "debug": "^4.3.3",
+                "socks": "^2.6.2"
               }
             }
           }
@@ -15101,16 +15995,16 @@
           }
         },
         "minipass-fetch": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
-          "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
+          "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
           "dev": true,
           "optional": true,
           "requires": {
-            "encoding": "^0.1.12",
-            "minipass": "^3.1.0",
+            "encoding": "^0.1.13",
+            "minipass": "^3.1.6",
             "minipass-sized": "^1.0.3",
-            "minizlib": "^2.0.0"
+            "minizlib": "^2.1.2"
           }
         },
         "minipass-flush": {
@@ -15196,9 +16090,9 @@
           "dev": true
         },
         "nan": {
-          "version": "2.15.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-          "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+          "version": "2.16.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+          "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
           "dev": true,
           "optional": true
         },
@@ -15239,16 +16133,16 @@
           }
         },
         "node-gyp": {
-          "version": "8.4.1",
-          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
-          "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.1.0.tgz",
+          "integrity": "sha512-HkmN0ZpQJU7FLbJauJTHkHlSVAXlNGDAzH/VYFZGDOnFyn/Na3GlNJfkudmufOdS6/jNFhy88ObzL7ERz9es1g==",
           "dev": true,
           "optional": true,
           "requires": {
             "env-paths": "^2.2.0",
             "glob": "^7.1.4",
             "graceful-fs": "^4.2.6",
-            "make-fetch-happen": "^9.1.0",
+            "make-fetch-happen": "^10.0.3",
             "nopt": "^5.0.0",
             "npmlog": "^6.0.0",
             "rimraf": "^3.0.2",
@@ -15258,9 +16152,9 @@
           },
           "dependencies": {
             "semver": {
-              "version": "7.3.5",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-              "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+              "version": "7.3.7",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+              "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -15302,15 +16196,15 @@
           "dev": true
         },
         "npmlog": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.0.tgz",
-          "integrity": "sha512-03ppFRGlsyUaQFbGC2C8QWJN/C/K7PsfyD9aQdhVKAQIH4sQBc8WASqFBP7O+Ut4d2oo5LoeoboB3cGdBZSp6Q==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+          "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "^2.0.0",
+            "are-we-there-yet": "^3.0.0",
             "console-control-strings": "^1.1.0",
-            "gauge": "^4.0.0",
+            "gauge": "^4.0.3",
             "set-blocking": "^2.0.0"
           }
         },
@@ -15651,7 +16545,7 @@
         "promise-inflight": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-          "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+          "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
           "dev": true,
           "optional": true
         },
@@ -15669,7 +16563,7 @@
             "retry": {
               "version": "0.12.0",
               "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-              "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+              "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
               "dev": true,
               "optional": true
             }
@@ -15836,15 +16730,15 @@
           }
         },
         "re2": {
-          "version": "1.17.3",
-          "resolved": "https://registry.npmjs.org/re2/-/re2-1.17.3.tgz",
-          "integrity": "sha512-Dp5iWVR8W3C7Nm9DziMY4BleMPRb/pe6kvfbzLv80dVYaXRc9jRnwwNqU0oE/taRm0qYR1+Qrtzk9rPjS9ecaQ==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/re2/-/re2-1.17.7.tgz",
+          "integrity": "sha512-X8GSuiBoVWwcjuppqSjsIkRxNUKDdjhkO9SBekQbZ2ksqWUReCy7DQPWOVpoTnpdtdz5PIpTTxTFzvJv5UMfjA==",
           "dev": true,
           "optional": true,
           "requires": {
-            "install-artifact-from-github": "^1.3.0",
-            "nan": "^2.15.0",
-            "node-gyp": "^8.4.1"
+            "install-artifact-from-github": "^1.3.1",
+            "nan": "^2.16.0",
+            "node-gyp": "^9.0.0"
           }
         },
         "readable-stream": {
@@ -16200,13 +17094,21 @@
           "dev": true
         },
         "socks": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
-          "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.0.tgz",
+          "integrity": "sha512-scnOe9y4VuiNUULJN72GrM26BNOjVsfPXI+j+98PkyEfsIXroa5ofyjT+FzGvn/xHs73U2JtoBYAVx9Hl4quSA==",
           "dev": true,
           "requires": {
-            "ip": "^1.1.5",
-            "smart-buffer": "^4.1.0"
+            "ip": "^2.0.0",
+            "smart-buffer": "^4.2.0"
+          },
+          "dependencies": {
+            "ip": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+              "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
+              "dev": true
+            }
           }
         },
         "socks-proxy-agent": {
@@ -16268,9 +17170,9 @@
           }
         },
         "ssri": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
-          "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
+          "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -16322,7 +17224,7 @@
         "string-length": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
-          "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
+          "integrity": "sha512-MNCACnufWUf3pQ57O5WTBMkKhzYIaKEcUioO0XHrTMafrbBaNk4IyDOLHBv5xbXO0jLLdsYWeFjpjG2hVHRDtw==",
           "dev": true,
           "requires": {
             "strip-ansi": "^3.0.0"
@@ -16331,7 +17233,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
               "dev": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -16406,13 +17308,13 @@
             "ansi-styles": {
               "version": "2.2.1",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+              "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
               "dev": true
             },
             "chalk": {
               "version": "1.1.3",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
               "dev": true,
               "requires": {
                 "ansi-styles": "^2.2.1",
@@ -16438,9 +17340,9 @@
               "dev": true
             },
             "commander": {
-              "version": "9.2.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
-              "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==",
+              "version": "9.4.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
+              "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
               "dev": true
             },
             "has-flag": {
@@ -16467,7 +17369,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
               "dev": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
@@ -16476,7 +17378,7 @@
             "supports-color": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
               "dev": true
             },
             "update-notifier": {
@@ -16762,19 +17664,19 @@
           }
         },
         "unique-filename": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-          "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
+          "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
           "dev": true,
           "optional": true,
           "requires": {
-            "unique-slug": "^2.0.0"
+            "unique-slug": "^3.0.0"
           }
         },
         "unique-slug": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
-          "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
+          "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -17390,6 +18292,12 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
     "http-parser-js": {
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
@@ -17541,15 +18449,6 @@
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
     "magic-string": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
@@ -17565,6 +18464,12 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "muggle-string": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.1.0.tgz",
+      "integrity": "sha512-Tr1knR3d2mKvvWthlk7202rywKbiOm4rVFLsfAaSIhJ6dt9o47W4S+JMtWhd/PW9Wrdew2/S2fSvhz3E2gkfEg==",
+      "dev": true
     },
     "nanoid": {
       "version": "3.3.4",
@@ -17657,9 +18562,9 @@
       }
     },
     "postcss": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
-      "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+      "version": "8.4.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.19.tgz",
+      "integrity": "sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==",
       "requires": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -17772,9 +18677,9 @@
       }
     },
     "rollup": {
-      "version": "2.78.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
-      "integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
+      "version": "2.79.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -17804,15 +18709,6 @@
         "jszip": "^3.6.0",
         "tmp": "^0.2.1",
         "ws": ">=7.4.6"
-      }
-    },
-    "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^6.0.0"
       }
     },
     "setimmediate": {
@@ -17906,16 +18802,16 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "vite": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-3.1.3.tgz",
-      "integrity": "sha512-/3XWiktaopByM5bd8dqvHxRt5EEgRikevnnrpND0gRfNkrMrPaGGexhtLCzv15RcCMtV2CLw+BPas8YFeSG0KA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.4.tgz",
+      "integrity": "sha512-Z2X6SRAffOUYTa+sLy3NQ7nlHFU100xwanq1WDwqaiFiCe+25zdxP1TfCS5ojPV2oDDcXudHIoPnI1Z/66B7Yw==",
       "dev": true,
       "requires": {
-        "esbuild": "^0.15.6",
+        "esbuild": "^0.15.9",
         "fsevents": "~2.3.2",
-        "postcss": "^8.4.16",
+        "postcss": "^8.4.18",
         "resolve": "^1.22.1",
-        "rollup": "~2.78.0"
+        "rollup": "^2.79.1"
       }
     },
     "vue": {
@@ -17938,14 +18834,24 @@
         "@vue/devtools-api": "^6.1.4"
       }
     },
-    "vue-tsc": {
-      "version": "0.39.5",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-0.39.5.tgz",
-      "integrity": "sha512-jhTsrKhZkafpIeN4Cbhr1K53hNfa/oesSrlh7hUaeHyCk55VhZT6oJkwJbtqN4MYkWZIwPrm3/xTwsELuf2ocg==",
+    "vue-template-compiler": {
+      "version": "2.7.14",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.14.tgz",
+      "integrity": "sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==",
       "dev": true,
       "requires": {
-        "@volar/vue-language-core": "0.39.5",
-        "@volar/vue-typescript": "0.39.5"
+        "de-indent": "^1.0.2",
+        "he": "^1.2.0"
+      }
+    },
+    "vue-tsc": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.0.10.tgz",
+      "integrity": "sha512-o6ek6ZSDwpVWn7/ZXlIILfCZ18o7ypEYKMDynsyPj9m10/ALXkCLKIj9yVfx00QAX5Z/hKrdhYcA2ZaQ0+U7Kg==",
+      "dev": true,
+      "requires": {
+        "@volar/vue-language-core": "1.0.10",
+        "@volar/vue-typescript": "1.0.10"
       }
     },
     "webidl-conversions": {
@@ -18002,12 +18908,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   "devDependencies": {
     "@types/quill": "^2.0.9",
     "@vitejs/plugin-vue": "^3.0.3",
-    "firebase-tools": "^11.13.0",
+    "firebase-tools": "^11.16.1",
     "sass": "^1.54.8",
     "typescript": "^4.6.4",
-    "vite": "^3.0.7",
-    "vue-tsc": "^0.39.5"
+    "vite": "^3.2.4",
+    "vue-tsc": "^1.0.10"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig(({command, mode }) => {
     },
     build: {
       minify: mode !== 'development',
-      // sourcemap: mode === 'development' // disabled for now: https://github.com/vitejs/vite/issues/10256
+      sourcemap: mode === 'development'
     }
   }
 })


### PR DESCRIPTION
## Description of the change

Addresses issue #64. This change should be pretty seamless. One thing to note is that source maps for the javascript files should now be generated when working locally. This helps tremendously with debugging. Vite fixed an issue where source maps were not generating properly.

**To test:**

1. Pull down the branch
2. Run `npm install`
3. Run `watch:dev`
4. Kick app around - look for errors.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Code review 

- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
