### PR TITLE
feature/#37-delete-flows

### DIFF
--- a/functions/triggers.js
+++ b/functions/triggers.js
@@ -139,9 +139,13 @@ exports.deleteCompetition = functions.firestore
       
       batch.commit()
 
-      // delete competition_projects
+      // delete competitions aggregate
       const aggregateDoc =  db.doc(`${KEY_AGGREGATES}/${AGGREGATE_ID_COMPS}`)
       aggregateDoc.delete()
+
+      // delete competition_projects ref
+      const compProjectsRef = db.collection(KEY_COMP_PROJECTS).doc(`${snap.id}`)
+      compProjectsRef.delete()
     })
 
 exports.updateProject = functions.firestore

--- a/functions/triggers.js
+++ b/functions/triggers.js
@@ -88,11 +88,11 @@ exports.deleteTeam = functions.firestore
         batch.delete(doc.ref)
       })
 
+      batch.commit()
+
       // delete team_projects ref
       const teamProjectsRef = db.collection(KEY_TEAM_PROJECTS).doc(`${snap.id}`)
-      batch.delete(teamProjectsRef)
-
-      batch.commit()
+       teamProjectsRef.delete()
 
       // delete team file uploads
       const bucket = admin.storage().bucket()
@@ -129,18 +129,19 @@ exports.updateCompetition = functions.firestore
 exports.deleteCompetition = functions.firestore
     .document('competitions/{competitionID}')
     .onDelete(async (snap, context) => {
-      // update projects Projects
+      // delete comp projects
       const batch = db.batch()
       const projectsRef = db.collection(KEY_PROJECTS)
       const projects = await projectsRef.where('competition.id', '==', snap.id).get()
       projects.forEach(doc => {
-        batch.update(doc.ref, { competition : null })
+        batch.delete(doc.ref)
       })
-      // delete competition_projects
-      const aggregateDoc =  db.doc(`${KEY_AGGREGATES}/${AGGREGATE_ID_COMPS}`)
-      batch.delete(aggregateDoc)
       
       batch.commit()
+
+      // delete competition_projects
+      const aggregateDoc =  db.doc(`${KEY_AGGREGATES}/${AGGREGATE_ID_COMPS}`)
+      aggregateDoc.delete()
     })
 
 exports.updateProject = functions.firestore

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@types/quill": "^2.0.9",
-        "@vitejs/plugin-vue": "^3.0.3",
+        "@vitejs/plugin-vue": "^3.2.0",
         "firebase-tools": "^11.16.1",
         "sass": "^1.54.8",
         "typescript": "^4.6.4",
@@ -724,9 +724,9 @@
       }
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-3.1.0.tgz",
-      "integrity": "sha512-fmxtHPjSOEIRg6vHYDaem+97iwCUg/uSIaTzp98lhELt2ISOQuDo2hbkBdXod0g15IhfPMQmAxh4heUks2zvDA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-3.2.0.tgz",
+      "integrity": "sha512-E0tnaL4fr+qkdCNxJ+Xd0yM31UwMkQje76fsDVBBUCoGOUPexu2VDUYHL8P4CwV+zMvWw6nlRw19OnRKmYAJpw==",
       "dev": true,
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -11270,9 +11270,9 @@
       }
     },
     "@vitejs/plugin-vue": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-3.1.0.tgz",
-      "integrity": "sha512-fmxtHPjSOEIRg6vHYDaem+97iwCUg/uSIaTzp98lhELt2ISOQuDo2hbkBdXod0g15IhfPMQmAxh4heUks2zvDA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-3.2.0.tgz",
+      "integrity": "sha512-E0tnaL4fr+qkdCNxJ+Xd0yM31UwMkQje76fsDVBBUCoGOUPexu2VDUYHL8P4CwV+zMvWw6nlRw19OnRKmYAJpw==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@types/quill": "^2.0.9",
-    "@vitejs/plugin-vue": "^3.0.3",
+    "@vitejs/plugin-vue": "^3.2.0",
     "firebase-tools": "^11.16.1",
     "sass": "^1.54.8",
     "typescript": "^4.6.4",

--- a/src/components/competition/CompetitionForm.vue
+++ b/src/components/competition/CompetitionForm.vue
@@ -237,7 +237,7 @@ export default defineComponent({
         {},
         compFactory(),
         this.competition
-      ), // clone so we can modify
+      ) as Competition, // clone so we can modify
       isSaving: false,
       startDate: this.competition.start_date && dateForInput(this.competition.start_date),
       endDate: this.competition.end_date && dateForInput(this.competition.end_date)
@@ -294,7 +294,7 @@ export default defineComponent({
     },
     confirmDelete(comp:Competition) {
       this.modalStore.options = {
-        title: 'Delete Competition?',
+        title: '',
         component: 'Confirm',
         meta: {
           message: `Are you sure you want to delete ${comp.name}?`,

--- a/src/components/competition/CompetitionForm.vue
+++ b/src/components/competition/CompetitionForm.vue
@@ -293,8 +293,9 @@ export default defineComponent({
         meta: {
           message: `Are you sure you want to delete ${comp.name}?`,
           confirm: () => { this.deleteCompetition(comp) },
-          confirmLabel: 'Delete',
-          cancelLabel: 'Cancel'
+          confirmLabel: 'Yes, I want to delete this competition',
+          cancelLabel: 'No, don\'t delete',
+          danger: true
         }
       }
     },

--- a/src/components/competition/CompetitionForm.vue
+++ b/src/components/competition/CompetitionForm.vue
@@ -228,7 +228,9 @@ export default defineComponent({
   props: {
     competition: {
       type: Object as () => Competition,
-      default: compFactory()
+      default() {
+        return compFactory()
+      }
     }
   },
   data() {

--- a/src/components/competition/CompetitionForm.vue
+++ b/src/components/competition/CompetitionForm.vue
@@ -198,26 +198,28 @@ function dateForSave(iso:string):Timestamp {
   return { seconds: date.getTime() / 1000, nanoseconds: 0 }
 }
 
-const DEFAULT_COMP = {
-  id: '',
-  name: '',
-  description: '',
-  rules: '',
-  judging_criteria: '',
-  success_criteria: '',
-  assessment_metric: '',
-  prizes_disabled: false,
-  prizes: {
-    first: '',
-    second: '',
-    third: ''
-  },
-  results: {},
-  results_disabled:true,
-  start_date: null,
-  end_date: null,
-  projects: []
-} as Competition
+function compFactory():Competition {
+  return {
+    id: '',
+    name: '',
+    description: '',
+    rules: '',
+    judging_criteria: '',
+    success_criteria: '',
+    assessment_metric: '',
+    prizes_disabled: false,
+    prizes: {
+      first: '',
+      second: '',
+      third: ''
+    },
+    results: {},
+    results_disabled:true,
+    start_date: null,
+    end_date: null,
+    projects: []
+  }
+}
 
 export default defineComponent({
   name: 'competition-form',
@@ -226,12 +228,16 @@ export default defineComponent({
   props: {
     competition: {
       type: Object as () => Competition,
-      default: DEFAULT_COMP
+      default: compFactory()
     }
   },
   data() {
     return {
-      clone: { ...DEFAULT_COMP, ...this.competition },
+      clone: Object.assign(
+        {},
+        compFactory(),
+        this.competition
+      ), // clone so we can modify
       isSaving: false,
       startDate: this.competition.start_date && dateForInput(this.competition.start_date),
       endDate: this.competition.end_date && dateForInput(this.competition.end_date)

--- a/src/components/competition/CompetitionForm.vue
+++ b/src/components/competition/CompetitionForm.vue
@@ -1,160 +1,177 @@
 <template>
-  <form @submit.prevent="submitForm" :disabled="isSaving">
-    <div class="field"> 
-      <label class="label">Competition Name</label>
-      <div class="control">
-        <input class="input" type="text" v-model="clone.name" required>
+  <section class="section">
+    <form @submit.prevent="submitForm" :disabled="isSaving">
+      <div class="field"> 
+        <label class="label">Competition Name</label>
+        <div class="control">
+          <input class="input" type="text" v-model="clone.name" required>
+        </div>
       </div>
-    </div>
-    <hr/>
-    <div>
-      <h2 class="title is-4">Dates</h2>
-      <h3 class="subtitle">Please list the beginning and the end date for your competition</h3>
-      <div class="is-flex is-flex-direction-row">
-        <div class="field mr-6"> 
-          <label class="label">Start Date</label>
+      <hr/>
+      <div>
+        <h2 class="title is-4">Dates</h2>
+        <h3 class="subtitle">Please list the beginning and the end date for your competition</h3>
+        <div class="is-flex is-flex-direction-row">
+          <div class="field mr-6"> 
+            <label class="label">Start Date</label>
+            <div class="control">
+              <input
+                class="input"
+                type="date"
+                v-model="startDate"
+                pattern="\d{4})-(\d{1,2})-(\d{1,2})"
+                required>
+            </div>
+          </div>
+          <div class="field"> 
+            <label class="label">End Date</label>
+            <div class="control">
+              <input 
+                class="input" 
+                type="date"
+                v-model="endDate"
+                :disabled="!startDate"
+                :min="minEndDate"
+                pattern="\d{4})-(\d{1,2})-(\d{1,2})"
+                required>
+            </div>
+          </div>
+        </div>
+      </div>
+      <hr/>
+      <div>
+        <h2 class="title is-4">Prizes</h2>
+        <h3 class="subtitle">List the prize amounts you will be awarding to the winners of your competition</h3>
+        <div class="field">
           <div class="control">
-            <input
-              class="input"
-              type="date"
-              v-model="startDate"
-              pattern="\d{4})-(\d{1,2})-(\d{1,2})"
-              required>
+          <label class="checkbox">
+            <input type="checkbox" v-model="clone.prizes_disabled">
+              Click this checkbox if you do not want to offer prizes as part of your competition
+            </label>
           </div>
         </div>
         <div class="field"> 
-          <label class="label">End Date</label>
+          <label class="label">First Prize</label>
+          <div class="control">
+            <input
+              class="input"
+              type="text"
+              v-model="clone.prizes.first"
+              :disabled="clone.prizes_disabled">
+          </div>
+        </div>
+        <div class="field"> 
+          <label class="label">Second Prize</label>
+          <div class="control">
+            <input
+              class="input"
+              type="text"
+              v-model="clone.prizes.second"
+              :disabled="clone.prizes_disabled">
+          </div>
+        </div>
+        <div class="field"> 
+          <label class="label">Runner Up</label>
+          <div class="control">
+            <input
+              class="input"
+              type="text"
+              v-model="clone.prizes.third"
+              :disabled="clone.prizes_disabled">
+          </div>
+        </div>
+      </div>
+      <hr/>
+      <div>
+        <h2 class="title is-4">Success Criteria</h2>
+        <h3 class="subtitle">How will people win your comeptittion. Please describe in as much detail as possible what the competitors have to do to win the competition.</h3>
+        <div class="field"> 
+          <label class="label">Describe how you will assess the winners of the competition</label>
+          <div class="control">
+            <text-editor 
+              :value="clone.success_criteria"
+              :placeholder="'Tell us about your competition'"
+              @text-change="(change) => clone.success_criteria = change" 
+            />
+          </div>
+        </div>
+        <div class="field"> 
+        <label class="label">Metric that will be used to measure the winner</label>
           <div class="control">
             <input 
               class="input" 
-              type="date"
-              v-model="endDate"
-              :disabled="!startDate"
-              :min="minEndDate"
-              pattern="\d{4})-(\d{1,2})-(\d{1,2})"
+              type="text" 
+              v-model="clone.assessment_metric" 
+              placeholder="Enter a value here e.g. &quot;grams of C02 captured&quot;"
               required>
           </div>
         </div>
       </div>
+      <hr/>
+      <div>
+        <h2 class="title is-4">Competition Details</h2>
+        <h3 class="subtitle">Please describe your competition in detail, the rules and the criteria by which a winner will be selected</h3>
+        <div class="field"> 
+          <label class="label">Description</label>
+          <div class="control">
+            <text-editor 
+              :value="clone.description"
+              :placeholder="'Tell us about your competition'"
+              @text-change="(change) => clone.description = change" 
+            />
+          </div>
+        </div>
+        <div class="field"> 
+          <label class="label">Rules</label>
+          <div class="control">
+            <text-editor 
+              :value="clone.rules"
+              :placeholder="'What are the rules of your competition?'"
+              @text-change="(change) => clone.rules = change" 
+            />
+          </div>
+        </div>
+        <div class="field"> 
+          <label class="label">Criteria</label>
+          <div class="control">
+            <text-editor 
+              :value="clone.judging_criteria"
+              :placeholder="'How will the winning entries be selected?'"
+              @text-change="(change) => clone.judging_criteria = change" 
+            />
+          </div>
+        </div>
+      </div>
+      <hr/>
+      <div class="field is-grouped is-grouped-right">
+        <div class="control">
+          <button @click="$emit('cancel')" class="button is-outlined">
+            Cancel
+          </button>
+        </div>
+        <div class="control">
+          <button type="submit" class="button is-primary">
+            Save Competition
+          </button>
+        </div>
+      </div>
+    </form>
+  </section>
+  <section class="section mt-6">
+    <div
+      v-if="competition.id"
+      class="p-4 has-background-light"
+    >
+      <h3 class="title is-5">Delete Competition</h3>
+      <p><strong>Warning:</strong> Deleting a Competition is irreversible. All associated data, including any submitted Projects, will also be deleted.</p>
+      <button
+        class="button is-danger mt-3"
+        @click="confirmDelete(competition)"
+      >
+        Delete Competition
+      </button>
     </div>
-    <hr/>
-    <div>
-      <h2 class="title is-4">Prizes</h2>
-      <h3 class="subtitle">List the prize amounts you will be awarding to the winners of your competition</h3>
-      <div class="field">
-        <div class="control">
-        <label class="checkbox">
-          <input type="checkbox" v-model="clone.prizes_disabled">
-            Click this checkbox if you do not want to offer prizes as part of your competition
-          </label>
-        </div>
-      </div>
-      <div class="field"> 
-        <label class="label">First Prize</label>
-        <div class="control">
-          <input
-            class="input"
-            type="text"
-            v-model="clone.prizes.first"
-            :disabled="clone.prizes_disabled">
-        </div>
-      </div>
-      <div class="field"> 
-        <label class="label">Second Prize</label>
-        <div class="control">
-          <input
-            class="input"
-            type="text"
-            v-model="clone.prizes.second"
-            :disabled="clone.prizes_disabled">
-        </div>
-      </div>
-      <div class="field"> 
-        <label class="label">Runner Up</label>
-        <div class="control">
-          <input
-            class="input"
-            type="text"
-            v-model="clone.prizes.third"
-            :disabled="clone.prizes_disabled">
-        </div>
-      </div>
-    </div>
-    <hr/>
-    <div>
-      <h2 class="title is-4">Success Criteria</h2>
-      <h3 class="subtitle">How will people win your comeptittion. Please describe in as much detail as possible what the competitors have to do to win the competition.</h3>
-      <div class="field"> 
-        <label class="label">Describe how you will assess the winners of the competition</label>
-        <div class="control">
-          <text-editor 
-            :value="clone.success_criteria"
-            :placeholder="'Tell us about your competition'"
-            @text-change="(change) => clone.success_criteria = change" 
-          />
-        </div>
-      </div>
-      <div class="field"> 
-      <label class="label">Metric that will be used to measure the winner</label>
-        <div class="control">
-          <input 
-            class="input" 
-            type="text" 
-            v-model="clone.assessment_metric" 
-            placeholder="Enter a value here e.g. &quot;grams of C02 captured&quot;"
-            required>
-        </div>
-      </div>
-    </div>
-    <hr/>
-    <div>
-      <h2 class="title is-4">Competition Details</h2>
-      <h3 class="subtitle">Please describe your competition in detail, the rules and the criteria by which a winner will be selected</h3>
-      <div class="field"> 
-        <label class="label">Description</label>
-        <div class="control">
-          <text-editor 
-            :value="clone.description"
-            :placeholder="'Tell us about your competition'"
-            @text-change="(change) => clone.description = change" 
-          />
-        </div>
-      </div>
-      <div class="field"> 
-        <label class="label">Rules</label>
-        <div class="control">
-          <text-editor 
-            :value="clone.rules"
-            :placeholder="'What are the rules of your competition?'"
-            @text-change="(change) => clone.rules = change" 
-          />
-        </div>
-      </div>
-      <div class="field"> 
-        <label class="label">Criteria</label>
-        <div class="control">
-          <text-editor 
-            :value="clone.judging_criteria"
-            :placeholder="'How will the winning entries be selected?'"
-            @text-change="(change) => clone.judging_criteria = change" 
-          />
-        </div>
-      </div>
-    </div>
-    <hr/>
-    <div class="field is-grouped is-grouped-right">
-      <div class="control">
-        <button @click="$emit('cancel')" class="button is-outlined">
-          Cancel
-        </button>
-      </div>
-      <div class="control">
-        <button type="submit" class="button is-primary">
-          Save Competition
-        </button>
-      </div>
-    </div>
-  </form>
+  </section>
 </template>
 
 <script lang="ts">
@@ -164,6 +181,7 @@ import { LogLevel } from '@/enums'
 import { mapStores } from 'pinia'
 import { useCompetitionsStore } from '@/store/competitions'
 import { useFlashStore } from '@/store/flash'
+import { useModalStore } from '@/store/modal'
 import { fsTimestampToDate, lastDayOfMonth } from '@/utils/date'
 import log from '@/services/logger'
 
@@ -202,6 +220,8 @@ const DEFAULT_COMP = {
 } as Competition
 
 export default defineComponent({
+  name: 'competition-form',
+  emits: ['cancel', 'comp-saved', 'comp-deleted'],
   components: { TextEditor: defineAsyncComponent(() => import('@/components/TextEditor.vue')) },
   props: {
     competition: {
@@ -218,7 +238,7 @@ export default defineComponent({
     }
   },
   computed: {
-    ...mapStores(useCompetitionsStore, useFlashStore),
+    ...mapStores(useCompetitionsStore, useFlashStore, useModalStore),
     minEndDate():string {
       let result = ''
       if (this.startDate) {
@@ -256,7 +276,7 @@ export default defineComponent({
           Object.assign(this.competition, result)
           this.clone = { ...this.competition }
           this.flashStore.$patch({ message: 'Competition saved', level: LogLevel.success })
-          this.$emit("comp-saved", result)
+          this.$emit('comp-saved', result)
         })
         .catch(error => {
           this.flashStore.$patch({ message: 'Error saving competition. Please try again.', level: LogLevel.error })
@@ -265,6 +285,31 @@ export default defineComponent({
         .finally(() => {
           this.isSaving = false
         })
+    },
+    confirmDelete(comp:Competition) {
+      this.modalStore.options = {
+        title: 'Delete Competition?',
+        component: 'Confirm',
+        meta: {
+          message: `Are you sure you want to delete ${comp.name}?`,
+          confirm: () => { this.deleteCompetition(comp) },
+          confirmLabel: 'Delete',
+          cancelLabel: 'Cancel'
+        }
+      }
+    },
+    deleteCompetition(comp:Competition) {
+      this.competitionsStore.deleteCompetition(comp)
+        .then(result => {
+            this.$emit('comp-deleted')
+          })
+          .catch(error => {
+            this.flashStore.$patch({ message: 'Error deleting competition. Please try again.', level: LogLevel.error })
+            log.error(MODULE_ID, error)
+          })
+          .finally(() => {
+            this.isSaving = false
+          })
     }
   }
 })

--- a/src/components/project/ProjectForm.vue
+++ b/src/components/project/ProjectForm.vue
@@ -85,7 +85,9 @@ export default defineComponent({
     },
     project: {
       type: Object as () => Project,
-      default: projectFactory()
+      default() {
+        return projectFactory()
+      }
     }
   },
   data() {

--- a/src/components/project/ProjectForm.vue
+++ b/src/components/project/ProjectForm.vue
@@ -162,8 +162,9 @@ export default defineComponent({
         meta: {
           message: `Are you sure you want to delete ${project.name}?`,
           confirm: () => { this.deleteProject(project) },
-          confirmLabel: 'Delete',
-          cancelLabel: 'Cancel'
+          confirmLabel: 'Yes, I want to delete this project',
+          cancelLabel: 'No, don\'t delete',
+          danger: true
         }
       }
     },

--- a/src/components/project/ProjectForm.vue
+++ b/src/components/project/ProjectForm.vue
@@ -94,7 +94,7 @@ export default defineComponent({
         {},
         projectFactory(),
         { team: this.team } 
-      ), // clone so we can modify
+      ) as Project, // clone so we can modify
       isSaving: false,
       inputRef: undefined as InstanceType<typeof ProjectInput>|undefined
     }
@@ -163,7 +163,7 @@ export default defineComponent({
     },
     confirmDelete(project:Project) {
       this.modalStore.options = {
-        title: 'Delete Project?',
+        title: '',
         component: 'Confirm',
         meta: {
           message: `Are you sure you want to delete ${project.name}?`,

--- a/src/components/project/ProjectForm.vue
+++ b/src/components/project/ProjectForm.vue
@@ -59,14 +59,20 @@ import log from '@/services/logger'
 const MODULE_ID = 'components/project/ProjectForm'
 
 const PROJECT_PARTIAL = {
-  id: '',
-  name: '',
-  terms: false,
-  design_doc_url: '',
-  materials: [],
-  team: undefined,
-  image: null
+
 } as Project
+
+function projectFactory():Project {
+  return {
+    id: '',
+    name: '',
+    terms: false,
+    design_doc_url: '',
+    materials: [],
+    team: undefined,
+    image: null
+  }
+}
 
 export default defineComponent({
   name: 'project-form',
@@ -79,16 +85,16 @@ export default defineComponent({
     },
     project: {
       type: Object as () => Project,
-      default: PROJECT_PARTIAL
+      default: projectFactory()
     }
   },
   data() {
     return {
-      clone: {
-        ...PROJECT_PARTIAL,
-        ...this.project,
-        ...{ team: this.team } 
-      } as Project,
+      clone: Object.assign(
+        {},
+        projectFactory(),
+        { team: this.team } 
+      ), // clone so we can modify
       isSaving: false,
       inputRef: undefined as InstanceType<typeof ProjectInput>|undefined
     }

--- a/src/components/project/ProjectForm.vue
+++ b/src/components/project/ProjectForm.vue
@@ -69,6 +69,8 @@ const PROJECT_PARTIAL = {
 } as Project
 
 export default defineComponent({
+  name: 'project-form',
+  emits: ['cancel', 'project-saved', 'project-deleted'],
   components: { Notification, ProjectInput },
   props: {
     team: {

--- a/src/components/team/TeamForm.vue
+++ b/src/components/team/TeamForm.vue
@@ -175,7 +175,9 @@ export default defineComponent({
   props: {
     team: {
       type: Object as () => Team,
-      default: teamFactory()
+      default() {
+        return teamFactory()
+      }
     }
   },
   data() {
@@ -218,8 +220,8 @@ export default defineComponent({
           .then(result => {
             if (result) {
               this.flashStore.$patch({ message: 'Team Avatar removed', level: LogLevel.success })
-              Object.assign(this.team, result)
-              this.clone = { ...this.team }
+              this.team.avatar = this.clone.avatar = null
+              this.avatarPreviewUrl = TEAM_AVATAR_PLACEHOLDER
             }
           })
           .catch(error => {
@@ -244,7 +246,7 @@ export default defineComponent({
         this.teamsStore.saveTeam(this.clone, file)
           .then(result => {
             Object.assign(this.team, result)
-            this.clone = { ...this.team}
+            this.clone = Object.assign({}, this.team)
             this.$emit('team-saved', this.clone)
           })
           .catch(error => {

--- a/src/components/team/TeamForm.vue
+++ b/src/components/team/TeamForm.vue
@@ -260,8 +260,9 @@ export default defineComponent({
         meta: {
           message: `Are you sure you want to delete ${team.name}?`,
           confirm: () => { this.deleteTeam(team) },
-          confirmLabel: 'Delete',
-          cancelLabel: 'Cancel'
+          confirmLabel: 'Yes, I want to delete this team',
+          cancelLabel: 'No, don\'t delete',
+          danger: true
         }
       }
     },

--- a/src/components/team/TeamForm.vue
+++ b/src/components/team/TeamForm.vue
@@ -1,124 +1,141 @@
 <template>
-  <form @submit.prevent="submitTeamForm" :disabled="isSaving">
-    <div class="is-flex is-flex-direction-row mb-4">
-      <div>
-        <div class="image is-128x128 mr-4">
-          <img :src="teamImageUrl" />
+  <section class="section">
+    <form @submit.prevent="submitTeamForm" :disabled="isSaving">
+      <div class="is-flex is-flex-direction-row mb-4">
+        <div>
+          <div class="image is-128x128 mr-4">
+            <img :src="teamImageUrl" />
+          </div>
         </div>
-      </div>
-      <div>
-        <label class="label">Team Avatar</label>
-        <button
-            v-if="clone.avatar"
-            @click.prevent="removeAvatar"
-            class="button is-warning"
-          >
-            Remove Avatar
-        </button>
-        <div v-else>
-          <p class="help is-info mb-2">
-           Accepts .jpeg, .jpg, and .png files only. Maximum file size is {{ kAvatarMaxSize / 1000 }}kb.
-          </p>
-          <div class="file mb-2">
-            <label class="file-label">
-              <input 
-                @change="showAvatarPreview"
-                class="file-input" 
-                type="file"
-                accept="image/*"
-                ref="file_avatar"
-              >
-              <span class="file-cta">
-                <span class="file-label">
-                  {{ teamImageUrl === kAvatarPlaceholder  ?  'Upload Team Avatar' : 'Change Avatar' }}
+        <div>
+          <label class="label">Team Avatar</label>
+          <button
+              v-if="clone.avatar"
+              @click.prevent="removeAvatar"
+              class="button is-warning"
+            >
+              Remove Avatar
+          </button>
+          <div v-else>
+            <p class="help is-info mb-2">
+            Accepts .jpeg, .jpg, and .png files only. Maximum file size is {{ kAvatarMaxSize / 1000 }}kb.
+            </p>
+            <div class="file mb-2">
+              <label class="file-label">
+                <input 
+                  @change="showAvatarPreview"
+                  class="file-input" 
+                  type="file"
+                  accept="image/*"
+                  ref="file_avatar"
+                >
+                <span class="file-cta">
+                  <span class="file-label">
+                    {{ teamImageUrl === kAvatarPlaceholder  ?  'Upload Team Avatar' : 'Change Avatar' }}
+                  </span>
                 </span>
-              </span>
-            </label>
+              </label>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-    <div class="field"> 
-      <label class="label">Team Name</label>
-      <div class="control">
-        <input class="input" type="text" v-model="clone.name" required>
-      </div>
-    </div>
-    <div class="field"> 
-      <label class="label">Where is your team located?</label>
-      <div class="control">
-        <input class="input" type="text" placeholder="City" v-model="clone.city" required>
-      </div>
-    </div>
-    <div class="field">
-      <div class="control">
-        <input class="input" type="text" placeholder="State/Province/Region" v-model="clone.region" required>
-      </div>
-    </div>
-    <div class="field">
-      <div class="control">
-        <input class="input" type="text" placeholder="Country" v-model="clone.country" required>
-      </div>
-    </div>
-    <hr/>
-    <div class="field"> 
-      <h2 class="title is-4">Team Members</h2>
-      <h3 class="subtitle">Add the discord handle of your team members</h3>
-      <div
-        v-for="(val, i) in clone.discord_usernames"
-        :key="i"
-        class="field is-grouped"
-      >
+      <div class="field"> 
+        <label class="label">Team Name</label>
         <div class="control">
-          <input
-          class="input" 
-          type="text" 
-          v-model="clone.discord_usernames[i]" /> 
+          <input class="input" type="text" v-model="clone.name" required>
         </div>
-        <div 
-          class="control"
+      </div>
+      <div class="field"> 
+        <label class="label">Where is your team located?</label>
+        <div class="control">
+          <input class="input" type="text" placeholder="City" v-model="clone.city" required>
+        </div>
+      </div>
+      <div class="field">
+        <div class="control">
+          <input class="input" type="text" placeholder="State/Province/Region" v-model="clone.region" required>
+        </div>
+      </div>
+      <div class="field">
+        <div class="control">
+          <input class="input" type="text" placeholder="Country" v-model="clone.country" required>
+        </div>
+      </div>
+      <hr/>
+      <div class="field"> 
+        <h2 class="title is-4">Team Members</h2>
+        <h3 class="subtitle">Add the discord handle of your team members</h3>
+        <div
+          v-for="(val, i) in clone.discord_usernames"
+          :key="i"
+          class="field is-grouped"
         >
-          <button
-            @click.prevent="clone.discord_usernames.splice(i, 1)" 
-            class="button is-text">
-            remove
+          <div class="control">
+            <input
+            class="input" 
+            type="text" 
+            v-model="clone.discord_usernames[i]" /> 
+          </div>
+          <div 
+            class="control"
+          >
+            <button
+              @click.prevent="clone.discord_usernames.splice(i, 1)" 
+              class="button is-text">
+              remove
+            </button>
+          </div>
+        </div>
+        <a
+          @click="clone.discord_usernames.push('')"
+          class="button is-primary m-2"
+        >
+          + Add More Members
+        </a>
+      </div>
+      <hr/>
+      <div class="field"> 
+        <label class="label">About your team</label>
+        <text-editor 
+          :value="clone.about"
+          :placeholder="kAboutPlacehoder"
+          @text-change="(change) => clone.about = change" 
+        />
+      </div>
+      <div class="field is-grouped is-grouped-right">
+        <div class="control">
+          <button @click="$emit('cancel')" class="button is-outlined">
+            Cancel
+          </button>
+        </div>
+        <div class="control">
+          <button 
+            type="submit"
+            class="button is-primary"
+            :class="{'is-loading': isSaving}"
+            :disabled="disableSubmit"
+          >
+            Save Team
           </button>
         </div>
       </div>
-      <a
-        @click="clone.discord_usernames.push('')"
-        class="button is-primary m-2"
+    </form>
+  </section>
+  <section class="section mt-6">
+    <div
+      v-if="team.id"
+      class="p-4 has-background-light"
+    >
+      <h3 class="title is-5">Delete Team</h3>
+      <p><strong>Warning:</strong> Deleting a Team is irreversible. All associated data will also be deleted.</p>
+      <button
+        class="button is-danger mt-3"
+        @click="confirmDelete(team)"
       >
-        + Add More Members
-      </a>
+        Delete Team
+      </button>
     </div>
-    <hr/>
-    <div class="field"> 
-      <label class="label">About your team</label>
-      <text-editor 
-        :value="clone.about"
-        :placeholder="kAboutPlacehoder"
-        @text-change="(change) => clone.about = change" 
-      />
-    </div>
-    <div class="field is-grouped is-grouped-right">
-      <div class="control">
-        <button @click="$emit('cancel')" class="button is-outlined">
-          Cancel
-        </button>
-      </div>
-      <div class="control">
-        <button 
-          type="submit"
-          class="button is-primary"
-          :class="{'is-loading': isSaving}"
-          :disabled="disableSubmit"
-        >
-          Save Team
-        </button>
-      </div>
-    </div>
-  </form>
+  </section>
 </template>
 
 <script lang="ts">
@@ -128,6 +145,7 @@ import { LogLevel, TeamRole } from '@/enums'
 import { mapStores } from 'pinia'
 import { useTeamsStore } from '@/store/teams'
 import { useFlashStore } from '@/store/flash'
+import { useModalStore } from '@/store/modal'
 import { TEAM_AVATAR_PLACEHOLDER } from '@/consts'
 import log from '@/services/logger'
 
@@ -167,7 +185,7 @@ export default defineComponent({
     }
   },
   computed: {
-    ...mapStores(useTeamsStore, useFlashStore),
+    ...mapStores(useTeamsStore, useFlashStore, useModalStore),
     teamImageUrl():string { 
       let result = this.avatarPreviewUrl || TEAM_AVATAR_PLACEHOLDER
       if (this.clone.avatar && this.clone.avatar.url) {
@@ -232,6 +250,31 @@ export default defineComponent({
       else {
         this.flashStore.$patch({ message:`The Avatar file size cannot exceed ${AVATAR_MAX_FILE_SIZE}kb.`, level: LogLevel.error })
       }
+    },
+    confirmDelete(team:Team) {
+      this.modalStore.options = {
+        title: 'Delete Team?',
+        component: 'Confirm',
+        meta: {
+          message: `Are you sure you want to delete ${team.name}?`,
+          confirm: () => { this.deleteTeam(team) },
+          confirmLabel: 'Delete',
+          cancelLabel: 'Cancel'
+        }
+      }
+    },
+    deleteTeam(team:Team) {
+      this.teamsStore.deleteTeam(team)
+        .then(result => {
+            this.$emit("team-deleted")
+          })
+          .catch(error => {
+            this.flashStore.$patch({ message: 'Error deleting team. Please try again.', level: LogLevel.error })
+            log.error(MODULE_ID, error)
+          })
+          .finally(() => {
+            this.isSaving = false
+          })
     }
   }
 })

--- a/src/components/team/TeamForm.vue
+++ b/src/components/team/TeamForm.vue
@@ -184,7 +184,7 @@ export default defineComponent({
         {}, 
         teamFactory(),
         this.team
-      ), // clone so we can modify
+      ) as Team, // clone so we can modify
       isSaving: false,
       kAvatarMaxSize: AVATAR_MAX_FILE_SIZE,
       kAvatarPlaceholder: TEAM_AVATAR_PLACEHOLDER,
@@ -261,7 +261,7 @@ export default defineComponent({
     },
     confirmDelete(team:Team) {
       this.modalStore.options = {
-        title: 'Delete Team?',
+        title: '',
         component: 'Confirm',
         meta: {
           message: `Are you sure you want to delete ${team.name}?`,

--- a/src/components/team/TeamForm.vue
+++ b/src/components/team/TeamForm.vue
@@ -167,6 +167,8 @@ const DEFAULT_TEAM = {
 } as Team
 
 export default defineComponent({
+  name: 'team-form',
+  emits: ['cancel', 'team-saved', 'team-deleted'],
   components: { TextEditor: defineAsyncComponent(() => import('@/components/TextEditor.vue')) },
   props: {
     team: {
@@ -237,7 +239,7 @@ export default defineComponent({
           .then(result => {
             Object.assign(this.team, result)
             this.clone = { ...this.team}
-            this.$emit("team-saved", this.clone)
+            this.$emit('team-saved', this.clone)
           })
           .catch(error => {
             this.flashStore.$patch({ message: 'Error saving team. Please try again.', level: LogLevel.error })
@@ -266,7 +268,7 @@ export default defineComponent({
     deleteTeam(team:Team) {
       this.teamsStore.deleteTeam(team)
         .then(result => {
-            this.$emit("team-deleted")
+            this.$emit('team-deleted')
           })
           .catch(error => {
             this.flashStore.$patch({ message: 'Error deleting team. Please try again.', level: LogLevel.error })

--- a/src/components/team/TeamForm.vue
+++ b/src/components/team/TeamForm.vue
@@ -153,18 +153,20 @@ const MODULE_ID = 'components/TeamForm'
 const AVATAR_MAX_FILE_SIZE = 200 * 1000 // 200kb
 const ABOUT_PLACEHOLDER = 'Tell us a bit about your team, what your areas of speciality are and what sort of projects you focus on.'
 
-const DEFAULT_TEAM = {
-  id: '',
-  name: '', 
-  city: '',
-  region: '',
-  country: '',
-  about: '',
-  avatar: null,
-  members: {},
-  recruiting: false,
-  discord_usernames: [''] as string[],
-} as Team
+function teamFactory():Team {
+  return {
+    id: '',
+    name: '', 
+    city: '',
+    region: '',
+    country: '',
+    about: '',
+    avatar: null,
+    members: {},
+    recruiting: false,
+    discord_usernames: [''] as string[]
+  }
+}
 
 export default defineComponent({
   name: 'team-form',
@@ -173,12 +175,16 @@ export default defineComponent({
   props: {
     team: {
       type: Object as () => Team,
-      default: DEFAULT_TEAM
+      default: teamFactory()
     }
   },
   data() {
     return {
-      clone: { ...DEFAULT_TEAM, ...this.team }, // clone so we can modify
+      clone: Object.assign(
+        {}, 
+        teamFactory(),
+        this.team
+      ), // clone so we can modify
       isSaving: false,
       kAvatarMaxSize: AVATAR_MAX_FILE_SIZE,
       kAvatarPlaceholder: TEAM_AVATAR_PLACEHOLDER,

--- a/src/jobs/firestore_sync.ts
+++ b/src/jobs/firestore_sync.ts
@@ -64,14 +64,24 @@ export function teamsSync(pinia:Pinia) {
             const match = teamsStore.list.find(t => t.id === change.doc.id)
             if (match) {
               const idx = teamsStore.list.indexOf(match)
-              teamsStore.list[idx] = { ...match, ...team }
+              if (change.type === 'removed') {
+                teamsStore.list = teamsStore.list.splice(idx, 1)
+              }
+              else {
+                teamsStore.list[idx] = { ...match, ...team }
+              }
             }
           }
           if (userStore.teams) {
             const match = userStore.teams.find(t => change.doc.id === change.doc.id) as Team
             if (match) {
               const idx = userStore.teams.indexOf(match)
-              userStore.teams[idx] = { ...match, ...team }
+              if (change.type === 'removed') {
+                userStore.teams = userStore.teams.splice(idx, 1)
+              }
+              else {
+                userStore.teams[idx] = { ...match, ...team }
+              }
             }
           }
         })

--- a/src/jobs/firestore_sync.ts
+++ b/src/jobs/firestore_sync.ts
@@ -73,15 +73,21 @@ export function teamsSync(pinia:Pinia) {
             }
           }
           if (userStore.teams) {
-            const match = userStore.teams.find(t => change.doc.id === change.doc.id) as Team
+            const match = userStore.teams.find(t => t.id === change.doc.id) as Team
             if (match) {
               const idx = userStore.teams.indexOf(match)
               if (change.type === 'removed') {
-                userStore.teams = userStore.teams.splice(idx, 1)
+                userStore.teams.splice(idx, 1)
               }
               else {
                 userStore.teams[idx] = { ...match, ...team }
               }
+            }
+          }
+          if (userStore.profile) {
+            const match = userStore.profile.teams && userStore.profile.teams[change.doc.id]
+            if (match && change.type === 'removed') {
+              delete userStore.profile.teams[change.doc.id]
             }
           }
         })

--- a/src/modals/Confirm.vue
+++ b/src/modals/Confirm.vue
@@ -7,6 +7,9 @@
           <button 
             class="button is-primary"
             @click="confirm"
+            :class="{
+              'is-danger': meta.danger
+            }"
           >
             {{ meta.confirmLabel }}
           </button>
@@ -26,6 +29,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue'
+import { LogLevel } from '@/enums'
 
 export default defineComponent({
   props: {
@@ -35,12 +39,14 @@ export default defineComponent({
         confirm:() => void
         confirmLabel: 'Confirm',
         cancelLabel: 'Cancel'
+        danger:false
       },
       required: true
     }
   },
   data() {
     return {
+      LogLevel,
       message: this.meta.message
     }
   },

--- a/src/modals/EnterCompetition.vue
+++ b/src/modals/EnterCompetition.vue
@@ -7,7 +7,7 @@
     <article class="is-flex-grow-1 px-4 py-6 has-background-white-bis">
       <loading v-if="step === eSteps.UNKNOWN" />
       <div v-if="step === eSteps.CREATE_FIRST_TEAM || step === eSteps.CREATE_TEAM">
-        <h3 class="title is-4">Create your first team</h3>
+        <h3 class="title is-4">Create your team</h3>
         <team-form 
           @team-saved="onTeamSaved"
           @cancel="onTeamFormCancel" 

--- a/src/store/competitions.ts
+++ b/src/store/competitions.ts
@@ -117,6 +117,16 @@ export const useCompetitionsStore = defineStore('competitions', {
         let message = (error instanceof Error) ? error.message : String(error)
         log.error(MODULE_ID, '#getCompetitionById > ' + message)
       }
+    },
+    async deleteCompetition(comp:Competition):Promise<void> {
+      try {
+        await firestore.deleteCompetition(comp)
+        this.list = this.list?.filter(c => c.id !== comp.id)
+      }
+      catch(error) {
+        let message = (error instanceof Error) ? error.message : String(error)
+        log.error(MODULE_ID, '#deleteCompetition > ' + message)
+      }
     }
   }
 })

--- a/src/store/teams.ts
+++ b/src/store/teams.ts
@@ -78,8 +78,6 @@ export const useTeamsStore = defineStore('teams', {
         }
         if (avatar) {
           await this.saveTeamAvatar(team, avatar)
-          response = await firestore.saveTeam(team)
-          team = { ...team, ...response }
         }
         return team
       }
@@ -161,7 +159,7 @@ export const useTeamsStore = defineStore('teams', {
       try {
         const response = await storage.saveFile(avatar, team.id)
         team.avatar = response
-        return team
+        return await this.saveTeam(team)
       }
       catch(error) {
         let message = (error instanceof Error) ? error.message : String(error)

--- a/src/store/teams.ts
+++ b/src/store/teams.ts
@@ -59,10 +59,7 @@ export const useTeamsStore = defineStore('teams', {
     },
     async saveTeam(team:Team, avatar?:File):Promise<Team|undefined> {
       try {
-        let creating = !team.id
-        if (avatar) {
-          await this.saveTeamAvatar(team, avatar)
-        }
+        const creating = !team.id
         let response = await firestore.saveTeam(team)
         team = { ...team, ...response }
         if(response && creating && this.list) {
@@ -79,7 +76,12 @@ export const useTeamsStore = defineStore('teams', {
           }
           this.list = list_patch
         }
-        return response
+        if (avatar) {
+          await this.saveTeamAvatar(team, avatar)
+          response = await firestore.saveTeam(team)
+          team = { ...team, ...response }
+        }
+        return team
       }
       catch(error) {
         let message = (error instanceof Error) ? error.message : String(error)

--- a/src/views/competitions/CompetitionEdit.vue
+++ b/src/views/competitions/CompetitionEdit.vue
@@ -17,6 +17,7 @@
         v-if="competition"
         :competition="competition"
         @cancel="onCancel"
+        @comp-deleted="onCompetitionDeleted"
       />
       <loading v-else />
     </article>
@@ -83,6 +84,15 @@ export default defineComponent({
             this.flashStore.$patch({ message: ERROR_AUTH, level: LogLevel.warning })
           })
       }
+    },
+    onCompetitionDeleted() {
+      this.$router.replace({ name: 'competitions'})
+        .then(()=> {
+          this.flashStore.$patch({ 
+            message: 'Competition deleted',
+            level: LogLevel.success
+          })
+        })
     },
     onCancel() {
       this.$router.replace({ name: 'comp-show', params: { id: this.$route.params.id }})

--- a/src/views/team_competitions/TeamCompetitions.vue
+++ b/src/views/team_competitions/TeamCompetitions.vue
@@ -6,7 +6,23 @@
       </h3>
     </header>
     <article class="article has-background-white-bis">
-      <competition-list :list="list" :showEnterButton="false" />
+      <competition-list
+        v-if="list.length"
+        :list="list" 
+        :showEnterButton="false" 
+      />
+      <div
+        v-else
+        class="is-flex is-flex-direction-column is-align-items-center is-justify-content-center"
+      >
+        <p class="mb-2">No competitions yet</p>
+        <router-link
+          :to="{ name: 'competitions' }"
+          class="button is-info"
+        >
+          Enter a competition
+        </router-link>
+      </div>
     </article>
   </section>
 </template>

--- a/src/views/team_projects/TeamProjectEdit.vue
+++ b/src/views/team_projects/TeamProjectEdit.vue
@@ -15,6 +15,7 @@
       :team="team"
       :project="project"
       @cancel="onCancel"
+      @project-deleted="onProjectDeleted"
     />
     <loading v-else />
   </section>
@@ -68,7 +69,16 @@ export default defineComponent({
     onCancel() {
       const project_id = this.$route.params.project_id
       this.$router.replace({ name: 'team-project-show', params: { project_id }})
-    }
+    },
+    onProjectDeleted() {
+      this.$router.replace({ name: 'team-show', params: { id: this.team.id }})
+        .then(()=> {
+          this.flashStore.$patch({ 
+            message: 'Project deleted',
+            level: LogLevel.success
+          })
+        })
+    },
   }
 })
 

--- a/src/views/team_projects/TeamProjects.vue
+++ b/src/views/team_projects/TeamProjects.vue
@@ -7,14 +7,23 @@
     </header>
     <article>
       <project-list
-        v-if="team.projects" 
+        v-if="team.projects && team.projects.length" 
         :list="team.projects"
         :can-edit="true"
         :show-team="false"
         @project-click="onProjectClick"
       />
-      <div v-else>
-        <h4 class="title is-5">No projects yet</h4>
+      <div
+        v-else
+        class="is-flex is-flex-direction-column is-align-items-center is-justify-content-center"
+      >
+        <p class="mb-2">You’ve got no projects, you must enter a competition to upload a project</p>
+        <router-link
+          :to="{ name: 'competitions' }"
+          class="button is-info"
+        >
+          Enter a competition
+        </router-link>
       </div>
     </article>
   </section>
@@ -51,7 +60,7 @@ export default defineComponent({
   },
   methods: {
     fetchProjects() {
-      if (!this.team.projects || !this.team.projects.length) {  
+      if (!this.team.projects || !this.team.projects.length) {
         this.teamsStore.fetchTeamProjects(this.team)
       }
     },

--- a/src/views/teams/TeamEdit.vue
+++ b/src/views/teams/TeamEdit.vue
@@ -21,6 +21,7 @@
         :team="team"
         @cancel="onCancel"
         @team-saved="onTeamSaved"
+        @team-deleted="onTeamDeleted"
       />
     </article>
   </section>
@@ -89,6 +90,15 @@ export default defineComponent({
     },
     onTeamSaved(team:Team) {
       this.flashStore.$patch({ message: 'Team saved', level: LogLevel.success })
+    },
+    onTeamDeleted() {
+      this.$router.replace({ name: 'my-teams'})
+        .then(()=> {
+          this.flashStore.$patch({ 
+            message: 'Team deleted',
+            level: LogLevel.success
+          })
+        })
     },
     onCancel() {
       if (this.team){

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig(({command, mode }) => {
     },
     build: {
       minify: mode !== 'development',
-      sourcemap: mode === 'development'
+      // sourcemap: mode === 'development' // still an issue https://github.com/vitejs/vite-plugin-vue/issues/35
     }
   }
 })


### PR DESCRIPTION
## Description of the change

Addresses issue #37 by adding deletion flows for Teams, Projects, and Competitions. I also fixed a few minor issues that have so far gone unreported. 

**Testing notes:**

1. Create Competition, Team, and Project models as needed
2. Delete buttons are found at the bottom of each models 'Edit' view
3. Deleting a Competition should also delete any associated Projects
4. Deleting a Team should also delete any associated Projects
5. Deleting a Project should just delete the project

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Code review 

- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
