### PR TITLE
update style.css to move where a warning element was placed

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -41,11 +41,14 @@ body {
 .firebase-emulator-warning {
   display: none;
 }
-
+/* 
 @media (min-width: 769px) and (max-width: 1086px) {
   .is-danger {
     position: relative;
     top: 2.5rem;
     left: -13rem;
   }
-}
+} */
+
+
+/* everything seems to be working correctly so far to put this in  a new space */

--- a/src/style.css
+++ b/src/style.css
@@ -41,3 +41,11 @@ body {
 .firebase-emulator-warning {
   display: none;
 }
+
+@media (min-width: 769px) and (max-width: 1086px) {
+  .is-danger {
+    position: relative;
+    top: 2.5rem;
+    left: -13rem;
+  }
+}

--- a/src/views/competitions/CompetitionShow.vue
+++ b/src/views/competitions/CompetitionShow.vue
@@ -320,8 +320,17 @@ export default defineComponent({
 
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
 .help {
   line-height: 30px;
 }
+
+p.help.is-danger {
+    @include tablet {
+      position: relative;
+      top: 2.5rem;
+      left: -13rem;
+    }
+}
 </style>
+


### PR DESCRIPTION
## Description of the change

> Addresses issue [#67 ] A paragraph warning element had been covering the counter in widths from 769px - 1086px.
1. I set a media query to move the error message under the button in a tablet view up to some desktop widths. 

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Code review 

- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
