### PR TITLE
Moved bulma sass utils import to vite css preproccessor

### DIFF
--- a/src/_bulma.scss
+++ b/src/_bulma.scss
@@ -1,4 +1,4 @@
-@import "bulma/sass/utilities/_all.sass";
+// @import "bulma/sass/utilities/_all.sass"; moved to vite.config.js
 @import "bulma/sass/base/_all.sass";
 @import "bulma/sass/form/_all.sass";
 @import "bulma/sass/grid/_all.sass";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,13 @@ export default defineConfig(({command, mode }) => {
         "@": fileURLToPath(new URL("./src", import.meta.url)),
       },
     },
+    css: {
+      preprocessorOptions: {
+        scss: {
+          additionalData: `@import "bulma/sass/utilities/_all.sass";`
+        }
+      },
+    },
     build: {
       minify: mode !== 'development',
       // sourcemap: mode === 'development' // still an issue https://github.com/vitejs/vite-plugin-vue/issues/35


### PR DESCRIPTION
## Description of the change

Addresses issue #71. Moved `@import "bulma/sass/utilities/_all.sass` from `_bulma.scss` to `vite.config.ts` so we can use mixins in Components

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Code review 

- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
